### PR TITLE
Add Fishing Shop items for GMS2 Region

### DIFF
--- a/Server/table/Server/shop_game.xml
+++ b/Server/table/Server/shop_game.xml
@@ -118,7 +118,6 @@
 		<item sn="23" id="20001759" grade="1" price="12170" prob="10000" randomOption="0" category="PS" feature="NewPotion01" locale="CN" /> 
 		<item sn="24" id="20001760" grade="1" price="18730" prob="10000" randomOption="0" category="PS" feature="NewPotion01" locale="CN" /> 
 		<item sn="25" id="20001761" grade="1" price="28800" prob="10000" randomOption="0" category="PS" feature="NewPotion01" locale="CN" /> 
-		
 	</shop>
 	<shop shopID="106">
 		<item sn="1" id="11300001" grade="1" price="1830" prob="60" randomOption="0" sellCount="1" category="CP" feature="Season1" />
@@ -5259,54 +5258,80 @@
 		<item sn="49" id="35000032" grade="1" price="1900" prob="10000" randomOption="0" category="Score" feature="DrumInstrument" />
 	</shop>
 	<shop shopID="161">
+		<item sn="1" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="1" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="1" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="2" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />
 		<item sn="2" id="20000276" grade="1" price="2500" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="2" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="3" id="32000008" grade="3" price="300000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" />
 		<item sn="3" id="20000307" grade="1" price="10000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="3" id="32000008" grade="3" price="300000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="4" id="32000011" grade="4" price="500000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" />
 		<item sn="4" id="20000308" grade="1" price="20000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="4" id="32000011" grade="4" price="500000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="5" id="32000054" grade="4" price="1000000" prob="10000" randomOption="0" requireAchieve="23100343,1" category="Fish" feature="Fishing02" />
 		<item sn="5" id="20000309" grade="1" price="50000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="5" id="32000054" grade="4" price="1000000" prob="10000" randomOption="0" requireAchieve="23100343,1" category="Fish" feature="Fishing02" locale="CN" />
+		<item sn="6" id="32000055" grade="4" price="2000000" prob="10000" randomOption="0" requireAchieve="23100344,1" category="Fish" feature="Fishing02" />
 		<item sn="6" id="20000310" grade="1" price="100000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="6" id="32000055" grade="4" price="2000000" prob="10000" randomOption="0" requireAchieve="23100344,1" category="Fish" feature="Fishing02" locale="CN" />
+		<item sn="7" id="11400383" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" />
 		<item sn="7" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="7" id="11400383" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="CN" />
+		<item sn="8" id="11500311" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" />
 		<item sn="8" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="8" id="11500311" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="CN" />
+		<item sn="9" id="11700411" grade="1" price="1000000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" />
 		<item sn="9" id="32000008" grade="3" price="300000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="9" id="11700411" grade="1" price="1000000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="CN" />
+		<item sn="10" id="11301371" grade="1" price="28000000" prob="10000" randomOption="0" requireAchieve="23100345,7" category="Skin" feature="Fishing02" />
 		<item sn="10" id="32000011" grade="4" price="500000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="10" id="11301371" grade="1" price="28000000" prob="10000" randomOption="0" requireAchieve="23100345,7" category="Skin" feature="Fishing02" locale="CN" />
+		<item sn="11" id="70700021" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100367,5" category="Badge" feature="Fishing02" />
 		<item sn="11" id="32000054" grade="4" price="1000000" prob="10000" randomOption="0" requireAchieve="23100343,1" category="Fish" feature="Fishing02" locale="KR" />
 		<item sn="11" id="70700021" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100367,5" category="Badge" feature="Fishing02" locale="CN" />
+		<item sn="12" id="70700022" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100369,1" category="Badge" feature="Fishing02" />
 		<item sn="12" id="32000055" grade="4" price="2000000" prob="10000" randomOption="0" requireAchieve="23100344,1" category="Fish" feature="Fishing02" locale="KR" />
 		<item sn="12" id="70700022" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100369,1" category="Badge" feature="Fishing02" locale="CN" />
+		<item sn="13" id="20200105" grade="1" price="25000000" prob="10000" randomOption="0" requireAchieve="23100363,5" category="Action" feature="Fishing02" />
 		<item sn="13" id="11400383" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="KR" />
 		<item sn="13" id="20200105" grade="1" price="25000000" prob="10000" randomOption="0" requireAchieve="23100363,5" category="Action" feature="Fishing02" locale="CN" />
+		<item sn="14" id="20001105" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" />
 		<item sn="14" id="11500311" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="KR" />
 		<item sn="14" id="20001105" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="CN" />
+		<item sn="15" id="20001108" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" />
 		<item sn="15" id="11700411" grade="1" price="1000000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="KR" />
 		<item sn="15" id="20001108" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="CN" />
+		<item sn="16" id="20001109" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" />
 		<item sn="16" id="11301371" grade="1" price="10000000" prob="10000" randomOption="0" requireAchieve="23100345,7" category="Skin" feature="Fishing02" locale="KR" />
 		<item sn="16" id="20001109" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="CN" />
+		<item sn="17" id="40100039" grade="1" price="1000" prob="10000" randomOption="0" category="FishEtc" feature="Fishing" />
 		<item sn="17" id="70700021" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100367,5" category="Badge" feature="Fishing02" locale="KR" />
 		<item sn="17" id="40100039" grade="1" price="1000" prob="10000" randomOption="0" category="FishEtc" feature="Fishing" locale="CN" />
+		<item sn="18" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="18" id="70700022" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100369,1" category="Badge" feature="Fishing02" locale="KR" />
 		<item sn="18" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
 		<item sn="19" id="20200105" grade="1" price="15000000" prob="10000" randomOption="0" requireAchieve="23100363,5" category="Action" feature="Fishing02" locale="KR" />
+		<item sn="20" id="20000919" grade="1" price="3000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="20" id="20001105" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="KR" />
 		<item sn="20" id="20000919" grade="1" price="3000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="21" id="20000920" grade="1" price="3500" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />
 		<item sn="21" id="20001108" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="KR" />
 		<item sn="21" id="20000920" grade="1" price="3500" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="22" id="20000921" grade="1" price="4000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" />
 		<item sn="22" id="20001109" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="KR" />
 		<item sn="22" id="20000921" grade="1" price="4000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="23" id="20000922" grade="1" price="5000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" />
 		<item sn="23" id="40100039" grade="1" price="1000" prob="10000" randomOption="0" category="FishEtc" feature="Fishing" locale="KR" />
 		<item sn="23" id="20000922" grade="1" price="5000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="24" id="20000923" grade="2" price="6000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="24" id="20000923" grade="2" price="6000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="25" id="20000924" grade="2" price="7000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />
 		<item sn="25" id="20000924" grade="2" price="7000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="26" id="20000925" grade="2" price="8000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" />
 		<item sn="26" id="20000925" grade="2" price="8000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="27" id="20000926" grade="2" price="10000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" />
 		<item sn="27" id="20000926" grade="2" price="10000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="CN" />
 	</shop>
 	<shop shopID="164">
@@ -5412,54 +5437,80 @@
 		<!-- <item sn="76" id="12100118" grade="4" price="100000" prob="10000" randomOption="0" category="PVPAcc" feature="PvPRankingDuelMode" locale="KR" /> -->
 	</shop>
 	<shop shopID="169">
+		<item sn="1" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="1" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="1" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="2" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />
 		<item sn="2" id="20000276" grade="1" price="2500" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="2" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="3" id="32000008" grade="3" price="300000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" />
 		<item sn="3" id="20000307" grade="1" price="10000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="3" id="32000008" grade="3" price="300000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="4" id="32000011" grade="4" price="500000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" />
 		<item sn="4" id="20000308" grade="1" price="20000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="4" id="32000011" grade="4" price="500000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="5" id="32000054" grade="4" price="1000000" prob="10000" randomOption="0" requireAchieve="23100343,1" category="Fish" feature="Fishing02" />
 		<item sn="5" id="20000309" grade="1" price="50000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="5" id="32000054" grade="4" price="1000000" prob="10000" randomOption="0" requireAchieve="23100343,1" category="Fish" feature="Fishing02" locale="CN" />
+		<item sn="6" id="32000055" grade="4" price="2000000" prob="10000" randomOption="0" requireAchieve="23100344,1" category="Fish" feature="Fishing02" />
 		<item sn="6" id="20000310" grade="1" price="100000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="6" id="32000055" grade="4" price="2000000" prob="10000" randomOption="0" requireAchieve="23100344,1" category="Fish" feature="Fishing02" locale="CN" />
+		<item sn="7" id="11400383" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" />
 		<item sn="7" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="7" id="11400383" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="CN" />
+		<item sn="8" id="11500311" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" />
 		<item sn="8" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="8" id="11500311" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="CN" />
+		<item sn="9" id="11700411" grade="1" price="1000000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" />
 		<item sn="9" id="32000008" grade="3" price="300000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="9" id="11700411" grade="1" price="1000000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="CN" />
+		<item sn="10" id="11301371" grade="1" price="28000000" prob="10000" randomOption="0" requireAchieve="23100345,7" category="Skin" feature="Fishing02" />
 		<item sn="10" id="32000011" grade="4" price="500000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="KR" />
 		<item sn="10" id="11301371" grade="1" price="28000000" prob="10000" randomOption="0" requireAchieve="23100345,7" category="Skin" feature="Fishing02" locale="CN" />
+		<item sn="11" id="70700021" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100367,5" category="Badge" feature="Fishing02" />
 		<item sn="11" id="32000054" grade="4" price="1000000" prob="10000" randomOption="0" requireAchieve="23100343,1" category="Fish" feature="Fishing02" locale="KR" />
 		<item sn="11" id="70700021" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100367,5" category="Badge" feature="Fishing02" locale="CN" />
+		<item sn="12" id="70700022" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100369,1" category="Badge" feature="Fishing02" />
 		<item sn="12" id="32000055" grade="4" price="2000000" prob="10000" randomOption="0" requireAchieve="23100344,1" category="Fish" feature="Fishing02" locale="KR" />
 		<item sn="12" id="70700022" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100369,1" category="Badge" feature="Fishing02" locale="CN" />
+		<item sn="13" id="20200105" grade="1" price="25000000" prob="10000" randomOption="0" requireAchieve="23100363,5" category="Action" feature="Fishing02" />
 		<item sn="13" id="11400383" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="KR" />
 		<item sn="13" id="20200105" grade="1" price="25000000" prob="10000" randomOption="0" requireAchieve="23100363,5" category="Action" feature="Fishing02" locale="CN" />
+		<item sn="14" id="20001105" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" />
 		<item sn="14" id="11500311" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="KR" />
 		<item sn="14" id="20001105" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="CN" />
+		<item sn="15" id="20001108" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" />
 		<item sn="15" id="11700411" grade="1" price="1000000" prob="10000" randomOption="0" requireAchieve="23100154,3" category="Skin" feature="Fishing" locale="KR" />
 		<item sn="15" id="20001108" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="CN" />
+		<item sn="16" id="20001109" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" />
 		<item sn="16" id="11301371" grade="1" price="10000000" prob="10000" randomOption="0" requireAchieve="23100345,7" category="Skin" feature="Fishing02" locale="KR" />
 		<item sn="16" id="20001109" grade="1" price="4500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="CN" />
+		<item sn="17" id="40100039" grade="1" price="1000" prob="10000" randomOption="0" category="FishEtc" feature="Fishing" />
 		<item sn="17" id="70700021" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100367,5" category="Badge" feature="Fishing02" locale="KR" />
 		<item sn="17" id="40100039" grade="1" price="1000" prob="10000" randomOption="0" category="FishEtc" feature="Fishing" locale="CN" />
+		<item sn="18" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="18" id="70700022" grade="3" price="45000000" prob="10000" randomOption="0" requireAchieve="23100369,1" category="Badge" feature="Fishing02" locale="KR" />
 		<item sn="18" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
 		<item sn="19" id="20200105" grade="1" price="15000000" prob="10000" randomOption="0" requireAchieve="23100363,5" category="Action" feature="Fishing02" locale="KR" />
+		<item sn="20" id="20000919" grade="1" price="3000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="20" id="20001105" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="KR" />
 		<item sn="20" id="20000919" grade="1" price="3000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="21" id="20000920" grade="1" price="3500" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />
 		<item sn="21" id="20001108" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="KR" />
 		<item sn="21" id="20000920" grade="1" price="3500" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="22" id="20000921" grade="1" price="4000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" />
 		<item sn="22" id="20001109" grade="1" price="1500000" prob="10000" randomOption="0" requireAchieve="23100345,5" category="FishEtc" feature="Fishing02" locale="KR" />
 		<item sn="22" id="20000921" grade="1" price="4000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="23" id="20000922" grade="1" price="5000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" />
 		<item sn="23" id="40100039" grade="1" price="1000" prob="10000" randomOption="0" category="FishEtc" feature="Fishing" locale="KR" />
 		<item sn="23" id="20000922" grade="1" price="5000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="24" id="20000923" grade="2" price="6000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="24" id="20000923" grade="2" price="6000" prob="10000" randomOption="0" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="25" id="20000924" grade="2" price="7000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />
 		<item sn="25" id="20000924" grade="2" price="7000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="26" id="20000925" grade="2" price="8000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" />
 		<item sn="26" id="20000925" grade="2" price="8000" prob="10000" randomOption="0" requireAchieve="23100137,1" category="Fish" feature="Fishing" locale="CN" />
+		<item sn="27" id="20000926" grade="2" price="10000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" />
 		<item sn="27" id="20000926" grade="2" price="10000" prob="10000" randomOption="0" requireAchieve="23100138,1" category="Fish" feature="Fishing" locale="CN" />
 	</shop>
 	<shop shopID="170">
@@ -7001,7 +7052,7 @@
 		<item sn="38" id="11800146" grade="1" paymentType="1" paymentItemID="30001215" paymentIconTag="30001153" price="10" prob="10000" randomOption="0" category="Skin" feature="Event" />
 	</shop>
 	<shop shopID="230">
-		<item sn="1" id="20000964" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
+		<item sn="1" id="20000949" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="2" id="20000265" grade="1" price="1000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="3" id="32000001" grade="1" price="5000" prob="10000" randomOption="0" category="Fish" feature="Fishing" />
 		<item sn="4" id="32000005" grade="2" price="100000" prob="10000" randomOption="0" requireAchieve="23100136,1" category="Fish" feature="Fishing" />


### PR DESCRIPTION
## Overview

I've added the Fisherman's Shop items for GMS2 Region as well as the Shop was empty before. It might not 100% be perfect and resemble to final state of the game but it was the closest I could get it with the available resources that could be found. Also the Pesca NPC at Rainbow Fishing Hole was updated to have the [Rainbow Magnetic Lure](https://maplestory2.fandom.com/wiki/Rainbow_Magnetic_Lure) as well. The ID that got replaced by it did not seem to exist.

## References that have been used
- https://youtu.be/UfhNeqAragU?si=Pu-JHOxuxlxKFqLK&t=283
- https://youtu.be/PM5JSEGCo2E?si=dfRQw8XpqLA7k48_&t=463
- https://maplestory2.fandom.com/wiki/Rainbow_Roller_Events

## Updated Shop Screenshots

### Pesca's Shop on Rainbow Fishing Hole:
<img width="821" height="712" alt="{90DA7C3C-BE44-49CD-B24E-B446AB1E5EF9}" src="https://github.com/user-attachments/assets/a2566f16-86aa-472e-ad22-31868484c2a2" />

### Fisherman's Shop:
<img width="823" height="714" alt="{C5A5E9CB-02FA-4CE8-8F74-AD16B6F544A0}" src="https://github.com/user-attachments/assets/03c5eafc-9fe6-4163-9f6f-a0476045f026" />
<img width="820" height="713" alt="{861B360F-8DAA-458A-97E9-7C2AE3C97DE3}" src="https://github.com/user-attachments/assets/8258f143-da40-4ee9-bcd2-87807e4c3b7e" />
<img width="824" height="715" alt="{4739314F-1B0F-4574-9A16-5724AF3065F9}" src="https://github.com/user-attachments/assets/1a575bfe-fa7f-4614-ab8f-062b6b9df5ad" />


