### PR TITLE
Fix AGENT argument delimiter in trigger XMLs

### DIFF
--- a/Xml/trigger/02000383_bf/01_mobspawn.xml
+++ b/Xml/trigger/02000383_bf/01_mobspawn.xml
@@ -1,229 +1,229 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
-  <state name="Setting">    <!-- 현재 이 파일 사용 안함, 나중에 혹시  사용할거 같아서 파일만 남겨둠 -->		
-    <onEnter>	
-			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>	
-			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" /> 					
-			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->		
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->			
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->		
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->			
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->				
-			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->					
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->			
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->	
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->		
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->		
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="1"/>	<!-- Stage02 -->	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="1"/>	<!-- Stage03 -->	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="1"/>	<!-- Stage04 -->		
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="1"/>	<!-- Stage05 -->						
-			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->	
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->		
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->		
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->	
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->		
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->					
+  <state name="Setting">    <!-- 현재 이 파일 사용 안함, 나중에 혹시  사용할거 같아서 파일만 남겨둠 -->
+    <onEnter>
+			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>
+			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" />
+			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="1"/>	<!-- Stage02 -->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="1"/>	<!-- Stage03 -->
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="1"/>	<!-- Stage04 -->
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="1"/>	<!-- Stage05 -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->
     </onEnter>
 			<condition name="CheckUser">
-				<transition state="LoadingDelay"/>	
-			</condition>	
+				<transition state="LoadingDelay"/>
+			</condition>
     <onExit>
     </onExit>
   </state>
 
     <state name="LoadingDelay" >
-        <onEnter>					
-				</onEnter>	
-				<condition name="WaitTick" waitTick="2000">	
-					<transition state="DungeonStart"/>	
-				</condition>				
-    <onExit> 	
+        <onEnter>
+				</onEnter>
+				<condition name="WaitTick" waitTick="2000">
+					<transition state="DungeonStart"/>
+				</condition>
+    <onExit>
     </onExit>
-    </state>	
-	
-   <state name="DungeonStart" >	
+    </state>
+
+   <state name="DungeonStart" >
         <onEnter>
         </onEnter>
 				<condition name="유저를감지했으면" arg1="9000">
-			<transition state="StageEnter" />	
+			<transition state="StageEnter" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageEnter" >	
+
+   <state name="StageEnter" >
         <onEnter>
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->		
-			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->			
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->
+			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage01MobSpawn" />	
+			<transition state="Stage01MobSpawn" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="Stage01MobSpawn" >		
+
+   <state name="Stage01MobSpawn" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126"  arg2="0"/>   		
- 			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!--Stage01 -->					
+			<action name="몬스터를생성한다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126"  arg2="0"/>
+ 			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!--Stage01 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126">
-			<transition state="Stage01DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>	
-   <state name="Stage01DoorOpen" >	
-        <onEnter>	
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->		
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->				
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->				
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage02MobSpawn" />	
+			<transition state="Stage01DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage02MobSpawn" >		
-        <onEnter>	
-			<action name="몬스터를생성한다" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226"  arg2="0"/>    
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	 <!--Stage02 -->				
+   <state name="Stage01DoorOpen" >
+        <onEnter>
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage02MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage02MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	 <!--Stage02 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226">
-			<transition state="Stage02DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage02DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->			
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->		
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->				
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->			
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage03MobSpawn" />	
+			<transition state="Stage02DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage03MobSpawn" >		
+   <state name="Stage02DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="0"/>	<!-- Stage03 -->					
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage03MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage03MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="0"/>	<!-- Stage03 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326">
-			<transition state="Stage03DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage03DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->			
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->				
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->		
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage04MobSpawn" />	
+			<transition state="Stage03DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage04MobSpawn" >		
+   <state name="Stage03DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="0"/>	<!-- Stage04 -->				
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage04MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage04MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="0"/>	<!-- Stage04 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426">
-			<transition state="Stage04DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage04DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->			
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->				
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->			
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage05MobSpawn" />		
+			<transition state="Stage04DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage05MobSpawn" >		
+   <state name="Stage04DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="0"/>	<!-- Stage05 -->					
-        </onEnter>
-		<condition name="몬스터가죽어있으면" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526">
-			<transition state="Stage05DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage05DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->			
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->		
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->				
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->				
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="BossStagePortalOpen" />		
+			<transition state="Stage05MobSpawn" />
         </condition>
-        <onExit>	
+        <onExit>
         </onExit>
     </state>
-	
-   <state name="BossStagePortalOpen" >	
+
+
+   <state name="Stage05MobSpawn" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage06 -->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->					
-			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" /> 	
+			<action name="몬스터를생성한다" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="0"/>	<!-- Stage05 -->
+        </onEnter>
+		<condition name="몬스터가죽어있으면" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526">
+			<transition state="Stage05DoorOpen" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+   <state name="Stage05DoorOpen" >
+        <onEnter>
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="BossStagePortalOpen" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+   <state name="BossStagePortalOpen" >
+        <onEnter>
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage06 -->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->
+			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" />
         </onEnter>
         <onExit>
         </onExit>

--- a/Xml/trigger/02000383_bf/1122330_dooropen.xml
+++ b/Xml/trigger/02000383_bf/1122330_dooropen.xml
@@ -1,190 +1,190 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
   <state name="Setting">
-    <onEnter>	
-			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>		
-			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" /> 									
-			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->		
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->			
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->		
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->			
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->				
-			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->					
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->			
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->	
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->		
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->		
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="1"/>	<!-- Stage02 -->	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="1"/>	<!-- Stage03 -->	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="1"/>	<!-- Stage04 -->		
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="1"/>	<!-- Stage05 -->						
-			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->	
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->		
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->		
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->	
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->		
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->	
-			<action name="SetUserValue" key="StageClear01" value="0" />		
-			<action name="SetUserValue" key="StageClear02" value="0" />		
-			<action name="SetUserValue" key="StageClear03" value="0" />		
-			<action name="SetUserValue" key="StageClear04" value="0" />		
-			<action name="SetUserValue" key="StageClear05" value="0" />					
+    <onEnter>
+			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>
+			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" />
+			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="1"/>	<!-- Stage02 -->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="1"/>	<!-- Stage03 -->
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="1"/>	<!-- Stage04 -->
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="1"/>	<!-- Stage05 -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->
+			<action name="SetUserValue" key="StageClear01" value="0" />
+			<action name="SetUserValue" key="StageClear02" value="0" />
+			<action name="SetUserValue" key="StageClear03" value="0" />
+			<action name="SetUserValue" key="StageClear04" value="0" />
+			<action name="SetUserValue" key="StageClear05" value="0" />
     </onEnter>
 			<condition name="CheckUser">
-				<transition state="LoadingDelay"/>	
-			</condition>	
+				<transition state="LoadingDelay"/>
+			</condition>
     <onExit>
     </onExit>
   </state>
 
     <state name="LoadingDelay" >
-        <onEnter>					
-				</onEnter>	
-				<condition name="WaitTick" waitTick="2000">	
-					<transition state="DungeonStart"/>	
-				</condition>				
-    <onExit> 	
+        <onEnter>
+				</onEnter>
+				<condition name="WaitTick" waitTick="2000">
+					<transition state="DungeonStart"/>
+				</condition>
+    <onExit>
     </onExit>
-    </state>	
-	
-   <state name="DungeonStart" >	
+    </state>
+
+   <state name="DungeonStart" >
         <onEnter>
         </onEnter>
 				<condition name="유저를감지했으면" arg1="9000">
-			<transition state="StageEnter" />	
+			<transition state="StageEnter" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageEnter" >	
+
+   <state name="StageEnter" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!-- StageEnter -->				
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->		
-			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->			
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!-- StageEnter -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->
+			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear01" param3="1"/> -->
-				<condition name="UserValue" key="StageClear01" value="1" >		
-					<transition state="StageClear01"/>	
-				</condition>		
+				<condition name="UserValue" key="StageClear01" value="1" >
+					<transition state="StageClear01"/>
+				</condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageClear01" >	
-        <onEnter>	
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	<!-- Stage01 -->				
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->		
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->				
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->				
+
+   <state name="StageClear01" >
+        <onEnter>
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	<!-- Stage01 -->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear02" param3="1"/> -->
-				<condition name="UserValue" key="StageClear02" value="1" >		
-					<transition state="StageClear02"/>	
-				</condition>			
-		
+				<condition name="UserValue" key="StageClear02" value="1" >
+					<transition state="StageClear02"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageClear02" >	
+
+   <state name="StageClear02" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="0"/>	<!-- Stage02 -->			
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->			
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->		
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->				
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->			
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="0"/>	<!-- Stage02 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear03" param3="1"/> -->
-				<condition name="UserValue" key="StageClear03" value="1" >		
-					<transition state="StageClear03"/>	
-				</condition>		
-				
+				<condition name="UserValue" key="StageClear03" value="1" >
+					<transition state="StageClear03"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear03" >	
+   <state name="StageClear03" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="0"/>	<!-- Stage03 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->			
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->				
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->		
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="0"/>	<!-- Stage03 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear04" param3="1"/> -->
-				<condition name="UserValue" key="StageClear04" value="1" >		
-					<transition state="StageClear04"/>	
-				</condition>				
-		
+				<condition name="UserValue" key="StageClear04" value="1" >
+					<transition state="StageClear04"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear04" >	
+   <state name="StageClear04" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="0"/>	<!-- Stage04 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->			
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->				
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->			
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="0"/>	<!-- Stage04 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear05" param3="1"/> -->
-				<condition name="UserValue" key="StageClear05" value="1" >		
-					<transition state="StageClear05"/>	
-				</condition>		
-				
+				<condition name="UserValue" key="StageClear05" value="1" >
+					<transition state="StageClear05"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear05" >	
+   <state name="StageClear05" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage05 -->				
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->			
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->		
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->				
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->				
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage05 -->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="BossStagePortalOpen" />		
+			<transition state="BossStagePortalOpen" />
         </condition>
-        <onExit>	
+        <onExit>
         </onExit>
     </state>
-	
-   <state name="BossStagePortalOpen" >	
+
+   <state name="BossStagePortalOpen" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage06 -->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->					
-			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" /> 	
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage06 -->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->
+			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" />
         </onEnter>
         <onExit>
         </onExit>

--- a/Xml/trigger/02000488_bf/01_mobspawn.xml
+++ b/Xml/trigger/02000488_bf/01_mobspawn.xml
@@ -1,229 +1,229 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
-  <state name="Setting">    <!-- 현재 이 파일 사용 안함, 나중에 혹시  사용할거 같아서 파일만 남겨둠 -->		
-    <onEnter>	
-			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>	
-			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" /> 					
-			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->		
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->			
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->		
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->			
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->				
-			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->					
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->			
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->	
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->		
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->		
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="1"/>	<!-- Stage02 -->	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="1"/>	<!-- Stage03 -->	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="1"/>	<!-- Stage04 -->		
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="1"/>	<!-- Stage05 -->						
-			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->	
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->		
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->		
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->	
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->		
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->					
+  <state name="Setting">    <!-- 현재 이 파일 사용 안함, 나중에 혹시  사용할거 같아서 파일만 남겨둠 -->
+    <onEnter>
+			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>
+			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" />
+			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="1"/>	<!-- Stage02 -->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="1"/>	<!-- Stage03 -->
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="1"/>	<!-- Stage04 -->
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="1"/>	<!-- Stage05 -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->
     </onEnter>
 			<condition name="CheckUser">
-				<transition state="LoadingDelay"/>	
-			</condition>	
+				<transition state="LoadingDelay"/>
+			</condition>
     <onExit>
     </onExit>
   </state>
 
     <state name="LoadingDelay" >
-        <onEnter>					
-				</onEnter>	
-				<condition name="WaitTick" waitTick="2000">	
-					<transition state="DungeonStart"/>	
-				</condition>				
-    <onExit> 	
+        <onEnter>
+				</onEnter>
+				<condition name="WaitTick" waitTick="2000">
+					<transition state="DungeonStart"/>
+				</condition>
+    <onExit>
     </onExit>
-    </state>	
-	
-   <state name="DungeonStart" >	
+    </state>
+
+   <state name="DungeonStart" >
         <onEnter>
         </onEnter>
 				<condition name="유저를감지했으면" arg1="9000">
-			<transition state="StageEnter" />	
+			<transition state="StageEnter" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageEnter" >	
+
+   <state name="StageEnter" >
         <onEnter>
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->		
-			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->			
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->
+			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage01MobSpawn" />	
+			<transition state="Stage01MobSpawn" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="Stage01MobSpawn" >		
+
+   <state name="Stage01MobSpawn" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126"  arg2="0"/>   		
- 			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!--Stage01 -->					
+			<action name="몬스터를생성한다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126"  arg2="0"/>
+ 			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!--Stage01 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126">
-			<transition state="Stage01DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>	
-   <state name="Stage01DoorOpen" >	
-        <onEnter>	
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->		
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->				
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->				
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage02MobSpawn" />	
+			<transition state="Stage01DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage02MobSpawn" >		
-        <onEnter>	
-			<action name="몬스터를생성한다" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226"  arg2="0"/>    
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	 <!--Stage02 -->				
+   <state name="Stage01DoorOpen" >
+        <onEnter>
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage02MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage02MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	 <!--Stage02 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226">
-			<transition state="Stage02DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage02DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->			
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->		
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->				
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->			
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage03MobSpawn" />	
+			<transition state="Stage02DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage03MobSpawn" >		
+   <state name="Stage02DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="0"/>	<!-- Stage03 -->					
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage03MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage03MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="0"/>	<!-- Stage03 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326">
-			<transition state="Stage03DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage03DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->			
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->				
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->		
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage04MobSpawn" />	
+			<transition state="Stage03DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage04MobSpawn" >		
+   <state name="Stage03DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="0"/>	<!-- Stage04 -->				
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage04MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage04MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="0"/>	<!-- Stage04 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426">
-			<transition state="Stage04DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage04DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->			
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->				
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->			
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage05MobSpawn" />		
+			<transition state="Stage04DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage05MobSpawn" >		
+   <state name="Stage04DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="0"/>	<!-- Stage05 -->					
-        </onEnter>
-		<condition name="몬스터가죽어있으면" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526">
-			<transition state="Stage05DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage05DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->			
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->		
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->				
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->				
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="BossStagePortalOpen" />		
+			<transition state="Stage05MobSpawn" />
         </condition>
-        <onExit>	
+        <onExit>
         </onExit>
     </state>
-	
-   <state name="BossStagePortalOpen" >	
+
+
+   <state name="Stage05MobSpawn" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage06 -->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->					
-			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" /> 	
+			<action name="몬스터를생성한다" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="0"/>	<!-- Stage05 -->
+        </onEnter>
+		<condition name="몬스터가죽어있으면" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526">
+			<transition state="Stage05DoorOpen" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+   <state name="Stage05DoorOpen" >
+        <onEnter>
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="BossStagePortalOpen" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+   <state name="BossStagePortalOpen" >
+        <onEnter>
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage06 -->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->
+			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" />
         </onEnter>
         <onExit>
         </onExit>

--- a/Xml/trigger/02000488_bf/1122330_dooropen.xml
+++ b/Xml/trigger/02000488_bf/1122330_dooropen.xml
@@ -1,190 +1,190 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
   <state name="Setting">
-    <onEnter>	
-			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>		
-			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" /> 									
-			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->		
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->			
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->		
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->			
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->				
-			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->					
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->			
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->	
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->		
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->		
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="1"/>	<!-- Stage02 -->	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="1"/>	<!-- Stage03 -->	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="1"/>	<!-- Stage04 -->		
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="1"/>	<!-- Stage05 -->						
-			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->	
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->		
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->		
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->	
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->		
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->	
-			<action name="SetUserValue" key="StageClear01" value="0" />		
-			<action name="SetUserValue" key="StageClear02" value="0" />		
-			<action name="SetUserValue" key="StageClear03" value="0" />		
-			<action name="SetUserValue" key="StageClear04" value="0" />		
-			<action name="SetUserValue" key="StageClear05" value="0" />					
+    <onEnter>
+			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>
+			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" />
+			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="1"/>	<!-- Stage02 -->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="1"/>	<!-- Stage03 -->
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="1"/>	<!-- Stage04 -->
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="1"/>	<!-- Stage05 -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->
+			<action name="SetUserValue" key="StageClear01" value="0" />
+			<action name="SetUserValue" key="StageClear02" value="0" />
+			<action name="SetUserValue" key="StageClear03" value="0" />
+			<action name="SetUserValue" key="StageClear04" value="0" />
+			<action name="SetUserValue" key="StageClear05" value="0" />
     </onEnter>
 			<condition name="CheckUser">
-				<transition state="LoadingDelay"/>	
-			</condition>	
+				<transition state="LoadingDelay"/>
+			</condition>
     <onExit>
     </onExit>
   </state>
 
     <state name="LoadingDelay" >
-        <onEnter>					
-				</onEnter>	
-				<condition name="WaitTick" waitTick="2000">	
-					<transition state="DungeonStart"/>	
-				</condition>				
-    <onExit> 	
+        <onEnter>
+				</onEnter>
+				<condition name="WaitTick" waitTick="2000">
+					<transition state="DungeonStart"/>
+				</condition>
+    <onExit>
     </onExit>
-    </state>	
-	
-   <state name="DungeonStart" >	
+    </state>
+
+   <state name="DungeonStart" >
         <onEnter>
         </onEnter>
 				<condition name="유저를감지했으면" arg1="9000">
-			<transition state="StageEnter" />	
+			<transition state="StageEnter" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageEnter" >	
+
+   <state name="StageEnter" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!-- StageEnter -->				
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->		
-			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->			
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!-- StageEnter -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->
+			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear01" param3="1"/> -->
-				<condition name="UserValue" key="StageClear01" value="1" >		
-					<transition state="StageClear01"/>	
-				</condition>		
+				<condition name="UserValue" key="StageClear01" value="1" >
+					<transition state="StageClear01"/>
+				</condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageClear01" >	
-        <onEnter>	
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	<!-- Stage01 -->				
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->		
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->				
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->				
+
+   <state name="StageClear01" >
+        <onEnter>
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	<!-- Stage01 -->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear02" param3="1"/> -->
-				<condition name="UserValue" key="StageClear02" value="1" >		
-					<transition state="StageClear02"/>	
-				</condition>			
-		
+				<condition name="UserValue" key="StageClear02" value="1" >
+					<transition state="StageClear02"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageClear02" >	
+
+   <state name="StageClear02" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="0"/>	<!-- Stage02 -->			
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->			
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->		
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->				
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->			
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="0"/>	<!-- Stage02 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear03" param3="1"/> -->
-				<condition name="UserValue" key="StageClear03" value="1" >		
-					<transition state="StageClear03"/>	
-				</condition>		
-				
+				<condition name="UserValue" key="StageClear03" value="1" >
+					<transition state="StageClear03"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear03" >	
+   <state name="StageClear03" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="0"/>	<!-- Stage03 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->			
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->				
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->		
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="0"/>	<!-- Stage03 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear04" param3="1"/> -->
-				<condition name="UserValue" key="StageClear04" value="1" >		
-					<transition state="StageClear04"/>	
-				</condition>				
-		
+				<condition name="UserValue" key="StageClear04" value="1" >
+					<transition state="StageClear04"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear04" >	
+   <state name="StageClear04" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="0"/>	<!-- Stage04 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->			
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->				
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->			
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="0"/>	<!-- Stage04 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear05" param3="1"/> -->
-				<condition name="UserValue" key="StageClear05" value="1" >		
-					<transition state="StageClear05"/>	
-				</condition>		
-				
+				<condition name="UserValue" key="StageClear05" value="1" >
+					<transition state="StageClear05"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear05" >	
+   <state name="StageClear05" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage05 -->				
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->			
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->		
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->				
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->				
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage05 -->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="BossStagePortalOpen" />		
+			<transition state="BossStagePortalOpen" />
         </condition>
-        <onExit>	
+        <onExit>
         </onExit>
     </state>
-	
-   <state name="BossStagePortalOpen" >	
+
+   <state name="BossStagePortalOpen" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage06 -->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->					
-			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" /> 	
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage06 -->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->
+			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" />
         </onEnter>
         <onExit>
         </onExit>

--- a/Xml/trigger/02000511_bf/01_mobspawn.xml
+++ b/Xml/trigger/02000511_bf/01_mobspawn.xml
@@ -1,229 +1,229 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
-  <state name="Setting">    <!-- 현재 이 파일 사용 안함, 나중에 혹시  사용할거 같아서 파일만 남겨둠 -->		
-    <onEnter>	
-			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>	
-			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" /> 					
-			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->		
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->			
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->		
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->			
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->				
-			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->					
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->			
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->	
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->		
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->		
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="1"/>	<!-- Stage02 -->	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="1"/>	<!-- Stage03 -->	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="1"/>	<!-- Stage04 -->		
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="1"/>	<!-- Stage05 -->						
-			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->	
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->		
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->		
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->	
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->		
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->					
+  <state name="Setting">    <!-- 현재 이 파일 사용 안함, 나중에 혹시  사용할거 같아서 파일만 남겨둠 -->
+    <onEnter>
+			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>
+			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" />
+			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="1"/>	<!-- Stage02 -->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="1"/>	<!-- Stage03 -->
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="1"/>	<!-- Stage04 -->
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="1"/>	<!-- Stage05 -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->
     </onEnter>
 			<condition name="CheckUser">
-				<transition state="LoadingDelay"/>	
-			</condition>	
+				<transition state="LoadingDelay"/>
+			</condition>
     <onExit>
     </onExit>
   </state>
 
     <state name="LoadingDelay" >
-        <onEnter>					
-				</onEnter>	
-				<condition name="WaitTick" waitTick="2000">	
-					<transition state="DungeonStart"/>	
-				</condition>				
-    <onExit> 	
+        <onEnter>
+				</onEnter>
+				<condition name="WaitTick" waitTick="2000">
+					<transition state="DungeonStart"/>
+				</condition>
+    <onExit>
     </onExit>
-    </state>	
-	
-   <state name="DungeonStart" >	
+    </state>
+
+   <state name="DungeonStart" >
         <onEnter>
         </onEnter>
 				<condition name="유저를감지했으면" arg1="9000">
-			<transition state="StageEnter" />	
+			<transition state="StageEnter" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageEnter" >	
+
+   <state name="StageEnter" >
         <onEnter>
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->		
-			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->			
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->
+			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage01MobSpawn" />	
+			<transition state="Stage01MobSpawn" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="Stage01MobSpawn" >		
+
+   <state name="Stage01MobSpawn" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126"  arg2="0"/>   		
- 			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!--Stage01 -->					
+			<action name="몬스터를생성한다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126"  arg2="0"/>
+ 			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!--Stage01 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126">
-			<transition state="Stage01DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>	
-   <state name="Stage01DoorOpen" >	
-        <onEnter>	
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->		
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->				
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->				
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage02MobSpawn" />	
+			<transition state="Stage01DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage02MobSpawn" >		
-        <onEnter>	
-			<action name="몬스터를생성한다" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226"  arg2="0"/>    
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	 <!--Stage02 -->				
+   <state name="Stage01DoorOpen" >
+        <onEnter>
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage02MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage02MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	 <!--Stage02 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226">
-			<transition state="Stage02DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage02DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->			
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->		
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->				
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->			
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage03MobSpawn" />	
+			<transition state="Stage02DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage03MobSpawn" >		
+   <state name="Stage02DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="0"/>	<!-- Stage03 -->					
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage03MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage03MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="0"/>	<!-- Stage03 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326">
-			<transition state="Stage03DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage03DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->			
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->				
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->		
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage04MobSpawn" />	
+			<transition state="Stage03DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage04MobSpawn" >		
+   <state name="Stage03DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="0"/>	<!-- Stage04 -->				
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="Stage04MobSpawn" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+
+   <state name="Stage04MobSpawn" >
+        <onEnter>
+			<action name="몬스터를생성한다" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="0"/>	<!-- Stage04 -->
         </onEnter>
 		<condition name="몬스터가죽어있으면" arg1="401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426">
-			<transition state="Stage04DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage04DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->			
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->				
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->			
-        </onEnter>
-		<condition name="WaitTick" waitTick="2000">
-			<transition state="Stage05MobSpawn" />		
+			<transition state="Stage04DoorOpen" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-	
-   <state name="Stage05MobSpawn" >		
+   <state name="Stage04DoorOpen" >
         <onEnter>
-			<action name="몬스터를생성한다" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"  arg2="0"/>   	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="0"/>	<!-- Stage05 -->					
-        </onEnter>
-		<condition name="몬스터가죽어있으면" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526">
-			<transition state="Stage05DoorOpen" />	
-        </condition>
-        <onExit>	
-        </onExit>
-    </state>
-   <state name="Stage05DoorOpen" >	
-        <onEnter>
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->			
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->		
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->				
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->				
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="BossStagePortalOpen" />		
+			<transition state="Stage05MobSpawn" />
         </condition>
-        <onExit>	
+        <onExit>
         </onExit>
     </state>
-	
-   <state name="BossStagePortalOpen" >	
+
+
+   <state name="Stage05MobSpawn" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage06 -->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->					
-			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" /> 	
+			<action name="몬스터를생성한다" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"  arg2="0"/>
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="0"/>	<!-- Stage05 -->
+        </onEnter>
+		<condition name="몬스터가죽어있으면" arg1="501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526">
+			<transition state="Stage05DoorOpen" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+   <state name="Stage05DoorOpen" >
+        <onEnter>
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+        </onEnter>
+		<condition name="WaitTick" waitTick="2000">
+			<transition state="BossStagePortalOpen" />
+        </condition>
+        <onExit>
+        </onExit>
+    </state>
+
+   <state name="BossStagePortalOpen" >
+        <onEnter>
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage06 -->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->
+			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" />
         </onEnter>
         <onExit>
         </onExit>

--- a/Xml/trigger/02000511_bf/1122330_dooropen.xml
+++ b/Xml/trigger/02000511_bf/1122330_dooropen.xml
@@ -1,190 +1,190 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
   <state name="Setting">
-    <onEnter>	
-			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>		
-			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" /> 									
-			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->		
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->			
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->		
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->			
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->				
-			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->					
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->			
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->	
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->	
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->		
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->		
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="1"/>	<!-- Stage02 -->	
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="1"/>	<!-- Stage03 -->	
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="1"/>	<!-- Stage04 -->		
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="1"/>	<!-- Stage05 -->						
-			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->	
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->		
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->		
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->	
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->		
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->	
-			<action name="SetUserValue" key="StageClear01" value="0" />		
-			<action name="SetUserValue" key="StageClear02" value="0" />		
-			<action name="SetUserValue" key="StageClear03" value="0" />		
-			<action name="SetUserValue" key="StageClear04" value="0" />		
-			<action name="SetUserValue" key="StageClear05" value="0" />					
+    <onEnter>
+			<action name="몬스터소멸시킨다" arg1="101,102,103,104,105,106,111,112,113,114,115,116,121,122,123,124,125,126,201,202,203,204,205,206,207,211,212,213,214,215,216,221,222,223,224,225,226,301,302,303,304,305,306,307,311,312,313,314,315,316,321,322,323,324,325,326,401,402,403,404,405,406,407,408,411,412,413,414,415,416,421,422,423,424,425,426,501,502,503,504,505,506,507,508,509,511,512,513,514,515,516,521,522,523,524,525,526"/>
+			<action name="포탈을설정한다" arg1="1" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="0" arg3="0" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="0" arg3="0" arg4="0" />
+			<action name="메쉬를설정한다" arg1="3001-3012" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorSide_AlwaysOn -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Closed" /> <!-- IronDoor_StageEnter-->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage01 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage02 -->
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage03 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage04-->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Closed" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3100" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="1" arg3="0" arg4="0" arg5="0" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="1" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="1"/> 	<!-- StageEnter -->
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="1"/>	<!-- Stage01 -->
+			<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="1"/>	<!-- Stage02 -->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="1"/>	<!-- Stage03 -->
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="1"/>	<!-- Stage04 -->
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="1"/>	<!-- Stage05 -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="0"/> <!-- Sound_IronDoorOpen_StageEnter-->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="0"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="0"/> <!-- Sound_PortalOn -->
+			<action name="SetUserValue" key="StageClear01" value="0" />
+			<action name="SetUserValue" key="StageClear02" value="0" />
+			<action name="SetUserValue" key="StageClear03" value="0" />
+			<action name="SetUserValue" key="StageClear04" value="0" />
+			<action name="SetUserValue" key="StageClear05" value="0" />
     </onEnter>
 			<condition name="CheckUser">
-				<transition state="LoadingDelay"/>	
-			</condition>	
+				<transition state="LoadingDelay"/>
+			</condition>
     <onExit>
     </onExit>
   </state>
 
     <state name="LoadingDelay" >
-        <onEnter>					
-				</onEnter>	
-				<condition name="WaitTick" waitTick="2000">	
-					<transition state="DungeonStart"/>	
-				</condition>				
-    <onExit> 	
+        <onEnter>
+				</onEnter>
+				<condition name="WaitTick" waitTick="2000">
+					<transition state="DungeonStart"/>
+				</condition>
+    <onExit>
     </onExit>
-    </state>	
-	
-   <state name="DungeonStart" >	
+    </state>
+
+   <state name="DungeonStart" >
         <onEnter>
         </onEnter>
 				<condition name="유저를감지했으면" arg1="9000">
-			<transition state="StageEnter" />	
+			<transition state="StageEnter" />
         </condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageEnter" >	
+
+   <state name="StageEnter" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!-- StageEnter -->				
-			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->		
-			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->	
-			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->			
+			<action name="AGENT를설정한다" arg1="8100,8101,8102,8103,8104,8105,8106,8107,8108" arg2="0"/> 	<!-- StageEnter -->
+			<action name="액터를설정한다" arg1="4000" arg2="1" arg3="Opened" /> <!-- IronDoor_StageEnter-->
+			<action name="메쉬를설정한다" arg1="3100" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StageEnter -->
+			<action name="이펙트를설정한다" arg1="5001" arg2="1"/> <!-- Sound_IronDoorOpen_StageEnter-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear01" param3="1"/> -->
-				<condition name="UserValue" key="StageClear01" value="1" >		
-					<transition state="StageClear01"/>	
-				</condition>		
+				<condition name="UserValue" key="StageClear01" value="1" >
+					<transition state="StageClear01"/>
+				</condition>
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageClear01" >	
-        <onEnter>	
-			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	<!-- Stage01 -->				
-			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->		
-			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->	
-			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->		
-			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->				
-			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->				
+
+   <state name="StageClear01" >
+        <onEnter>
+			<action name="AGENT를설정한다" arg1="8200,8201,8202,8203,8204,8205,8206,8207,8208,8209,8210,8211,8212" arg2="0"/>	<!-- Stage01 -->
+			<action name="액터를설정한다" arg1="4001" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage01 -->
+			<action name="메쉬를설정한다" arg1="3101,3110,3111" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage01 -->
+			<action name="메쉬를설정한다" arg1="5110-5113" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage01 -->
+			<action name="메쉬애니를설정한다" arg1="5110,5111,5112,5113" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage01 -->
+			<action name="이펙트를설정한다" arg1="5002,5100,5101" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage01-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear02" param3="1"/> -->
-				<condition name="UserValue" key="StageClear02" value="1" >		
-					<transition state="StageClear02"/>	
-				</condition>			
-		
+				<condition name="UserValue" key="StageClear02" value="1" >
+					<transition state="StageClear02"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
-	
-   <state name="StageClear02" >	
+
+   <state name="StageClear02" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8300.8301.8302.8303.8304.8305.8306.8307.8308.8309.8310.8311.8312" arg2="0"/>	<!-- Stage02 -->			
-			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->			
-			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->	
-			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->		
-			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->				
-			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->			
+					<action name="AGENT를설정한다" arg1="8300,8301,8302,8303,8304,8305,8306,8307,8308,8309,8310,8311,8312" arg2="0"/>	<!-- Stage02 -->
+			<action name="액터를설정한다" arg1="4002" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage02 -->
+			<action name="메쉬를설정한다" arg1="3102,3120,3121" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage02 -->
+			<action name="메쉬를설정한다" arg1="5210-5213" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage02 -->
+			<action name="메쉬애니를설정한다" arg1="5210,5211,5212,5213" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage02 -->
+			<action name="이펙트를설정한다" arg1="5003,5200,5201" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage02-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear03" param3="1"/> -->
-				<condition name="UserValue" key="StageClear03" value="1" >		
-					<transition state="StageClear03"/>	
-				</condition>		
-				
+				<condition name="UserValue" key="StageClear03" value="1" >
+					<transition state="StageClear03"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear03" >	
+   <state name="StageClear03" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8400.8401.8402.8403.8404.8405.8406.8407.8408.8409.8410.8411.8412" arg2="0"/>	<!-- Stage03 -->			
-			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->			
-			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->	
-			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->		
-			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->				
-			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->		
+			<action name="액터를설정한다" arg1="4003" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage03 -->
+			<action name="메쉬를설정한다" arg1="3103,3130,3131" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage03 -->
+			<action name="메쉬를설정한다" arg1="5310-5313" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage03 -->
+			<action name="메쉬애니를설정한다" arg1="5310,5311,5312,5313" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage03 -->
+			<action name="이펙트를설정한다" arg1="5004,5300,5301" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage03-->
+			<action name="AGENT를설정한다" arg1="8400,8401,8402,8403,8404,8405,8406,8407,8408,8409,8410,8411,8412" arg2="0"/>	<!-- Stage03 -->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear04" param3="1"/> -->
-				<condition name="UserValue" key="StageClear04" value="1" >		
-					<transition state="StageClear04"/>	
-				</condition>				
-		
+				<condition name="UserValue" key="StageClear04" value="1" >
+					<transition state="StageClear04"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear04" >	
+   <state name="StageClear04" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8500.8501.8502.8503.8504.8505.8506.8507.8508.8509.8510.8511.8512" arg2="0"/>	<!-- Stage04 -->			
-			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->			
-			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->	
-			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->		
-			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->				
-			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->			
+			<action name="AGENT를설정한다" arg1="8500,8501,8502,8503,8504,8505,8506,8507,8508,8509,8510,8511,8512" arg2="0"/>	<!-- Stage04 -->
+			<action name="액터를설정한다" arg1="4004" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage04 -->
+			<action name="메쉬를설정한다" arg1="3104,3140,3141" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage04 -->
+			<action name="메쉬를설정한다" arg1="5410-5413" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage04 -->
+			<action name="메쉬애니를설정한다" arg1="5410,5411,5412,5413" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage04 -->
+			<action name="이펙트를설정한다" arg1="5005,5400,5401" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage04-->
         </onEnter>
 				<!-- 23000083 보스 한테 신호 받기 대기  <event eventName="TriggerEvent" target="SetUserValue" param1="1122330" param2="StageClear05" param3="1"/> -->
-				<condition name="UserValue" key="StageClear05" value="1" >		
-					<transition state="StageClear05"/>	
-				</condition>		
-				
+				<condition name="UserValue" key="StageClear05" value="1" >
+					<transition state="StageClear05"/>
+				</condition>
+
         <onExit>
         </onExit>
     </state>
 
-   <state name="StageClear05" >	
+   <state name="StageClear05" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage05 -->				
-			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->			
-			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->		
-			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->				
-			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->			
-			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->				
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage05 -->
+			<action name="액터를설정한다" arg1="4005" arg2="1" arg3="Opened" /> <!-- IronDoor_Stage05 -->
+			<action name="메쉬를설정한다" arg1="3105,3150,3151" arg2="0" arg3="0" arg4="0" arg5="0" /> <!-- DoorBarrier_StairsBarrier_Stage05 -->
+			<action name="메쉬를설정한다" arg1="5510-5515" arg2="0" arg3="500" arg4="0" arg5="5" /> <!-- BlueLight_Stage05 -->
+			<action name="메쉬애니를설정한다" arg1="5510,5511,5512,5513,5514,5515" arg2="0" arg3="0" arg4="0" /> <!-- BlueLight_Stage05 -->
+			<action name="이펙트를설정한다" arg1="5006,5500,5501" arg2="1"/> <!-- Sound_IronDoorOpen_IceMelt_Stage05-->
         </onEnter>
 		<condition name="WaitTick" waitTick="2000">
-			<transition state="BossStagePortalOpen" />		
+			<transition state="BossStagePortalOpen" />
         </condition>
-        <onExit>	
+        <onExit>
         </onExit>
     </state>
-	
-   <state name="BossStagePortalOpen" >	
+
+   <state name="BossStagePortalOpen" >
         <onEnter>
-			<action name="AGENT를설정한다" arg1="8600.8601.8602.8603.8604.8605.8606.8607.8608.8609.8610.8611.8612" arg2="0"/>	<!-- Stage06 -->		
-			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->					
-			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" /> 	
-			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" /> 		
-			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" /> 	
+			<action name="AGENT를설정한다" arg1="8600,8601,8602,8603,8604,8605,8606,8607,8608,8609,8610,8611,8612" arg2="0"/>	<!-- Stage06 -->
+			<action name="이펙트를설정한다" arg1="5007,5008,5009" arg2="1"/> <!-- Sound_PortalOn -->
+			<action name="포탈을설정한다" arg1="1" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="2" arg2="1" arg3="1" arg4="0" />
+			<action name="포탈을설정한다" arg1="3" arg2="1" arg3="1" arg4="0" />
         </onEnter>
         <onExit>
         </onExit>


### PR DESCRIPTION
Replaces incorrect '.' delimiters with ',' in AGENT action argument lists across mobspawn and dooropen trigger XML files for maps 02000383_bf, 02000488_bf, and 02000511_bf. This ensures proper parsing and execution of agent settings for each stage.