### PR TITLE
Add missing Limit Break trophy (23200043) strings for all languages

### DIFF
--- a/Xml/string/de/achievedescription.xml
+++ b/Xml/string/de/achievedescription.xml
@@ -1613,6 +1613,7 @@
 	<achieve id="23200040" desc="Erreiche Rüstwert {0}." complete="Rüstwert {0} erreicht." manualDesc="" manualComplete="" feature="Season1" />
 	<achieve id="23200041" desc="Gib 500 Pilzmark auf dem Pilzmarkt aus." complete="500 Pilzmark auf dem Pilzmarkt ausgegeben." manualDesc="" manualComplete="" feature="Season1" />
 	<achieve id="23200042" desc="Aktiviere {0} Mal einen goldenen Royale-Pass." complete="{0} Mal einen goldenen Royale-Pass aktiviert." manualDesc="" manualComplete="" feature="SurvivalContents03" />
+	<achieve id="23200043" desc="Limitdurchbruch {0}-mal abschließen" complete="Limitdurchbruch {0}-mal abgeschlossen" manualDesc="" manualComplete="" feature="UnlimitedEnchant" />
 	<achieve id="23300002" desc="" complete="" manualDesc="Sammle die Blökmobiltrophäe." manualComplete="Die Blökmobiltrophäe gesammelt." feature="Season1" />
 	<achieve id="23300003" desc="" complete="" manualDesc="Sammle alle aktuellsten Ausgaben beliebter Zeitschriften." manualComplete="Alle aktuellsten Ausgaben beliebter Zeitschriften gesammelt." feature="Season1" />
 	<achieve id="23300004" desc="" complete="" manualDesc="Sammle das Buch „$item:39000001$“." manualComplete="Das Buch „$item:39000001$“ gesammelt." feature="Season1" />

--- a/Xml/string/de/achievename.xml
+++ b/Xml/string/de/achievename.xml
@@ -1724,6 +1724,7 @@
 	<key id="23200040" name="Bereit für Größeres" feature="Season1" />
 	<key id="23200041" name="Ich brauche es!" feature="Season1" />
 	<key id="23200042" name="(Konto) Pilzköniglich" feature="SurvivalContents03" />
+	<key id="23200043" name="Grenzen durchbrechen" feature="UnlimitedEnchant" />
 	<key id="23300002" name="Zottellamm" />
 	<key id="23300003" name="Vorreiter" />
 	<key id="23300004" name="$item:39000001$" />

--- a/Xml/string/en/achievedescription.xml
+++ b/Xml/string/en/achievedescription.xml
@@ -1640,6 +1640,7 @@
 	<achieve id="23200040" desc="Reach Gear Score {0}" complete="Reached Gear Score {0}" manualDesc="" manualComplete="" feature="Season1" />
 	<achieve id="23200041" desc="Spend 500 merets at the Meret Market" complete="Spent 500 merets at the Meret Market" manualDesc="" manualComplete="" feature="Season1" />
 	<achieve id="23200042" desc="Activate {0} Gold Royale Pass" complete="Activated {0} Gold Royale Pass" manualDesc="" manualComplete="" feature="SurvivalContents03" />
+	<achieve id="23200043" desc="Complete Limit Break {0} time(s)" complete="Completed Limit Break {0} time(s)" manualDesc="" manualComplete="" feature="UnlimitedEnchant" />
 	<achieve id="23300002" desc="" complete="" manualDesc="Acquire the Birk mount trophy" manualComplete="Acquired the Birk mount trophy" feature="Season1" />
 	<achieve id="23300003" desc="" complete="" manualDesc="Collect all of the latest popular magazines" manualComplete="Collected all of the latest popular magazines" feature="Season1" />
 	<achieve id="23300004" desc="" complete="" manualDesc='Collect the book &quot;$item:39000001$&quot;' manualComplete='Collected the book &quot;$item:39000001$&quot;' feature="Season1" />

--- a/Xml/string/en/achievename.xml
+++ b/Xml/string/en/achievename.xml
@@ -1752,6 +1752,7 @@
 	<key id="23200040" name="Ready for the Big Leagues" feature="Season1" />
 	<key id="23200041" name="I Need It!" feature="Season1" />
 	<key id="23200042" name="(Account) Royalety" feature="SurvivalContents03" />
+	<key id="23200043" name="Push The Limits" feature="UnlimitedEnchant" />
 	<key id="23300002" name="Shaggy Lamb" />
 	<key id="23300003" name="Trend-setter" />
 	<key id="23300004" name="$item:39000001$" />

--- a/Xml/string/jp/achievedescription.xml
+++ b/Xml/string/jp/achievedescription.xml
@@ -1780,7 +1780,7 @@
   <achieve id="23200040" desc="アイテムスコア{0}点を達成する" complete="アイテムスコア{0}点を達成する" manualDesc="" manualComplete="" feature="Season1" />
   <achieve id="23200041" desc="アイテムショップで500ブルーメロットを使用する" complete="アイテムショップで500ブルーメロットを使用する" manualDesc="" manualComplete="" feature="Season1" />
   <achieve id="23200042" desc="ゴールドパスを{0}回活性化する" complete="ゴールドパスを{0}回活性化する" manualDesc="" manualComplete="" feature="SurvivalContents03" />
-  <achieve id="23200043" desc="ACHIEVEDESCRIPTION_23200043_DESC:[F]UnlimitedEnchant" complete="ACHIEVEDESCRIPTION_23200043_COMPLETE:[F]UnlimitedEnchant" manualDesc="" manualComplete="" feature="UnlimitedEnchant" />
+  <achieve id="23200043" desc="限界突破を{0}回完了する" complete="限界突破を{0}回完了" manualDesc="" manualComplete="" feature="UnlimitedEnchant" />
   <achieve id="23300002" desc="" complete="" manualDesc="バク系乗り物のトロフィーを獲得する" manualComplete="バク系乗り物のトロフィーを獲得する" feature="Season1" />
   <achieve id="23300003" desc="" complete="" manualDesc="最新流行雑誌を全てを収集する" manualComplete="最新流行雑誌を全てを収集する" feature="Season1" />
   <achieve id="23300004" desc="" complete="" manualDesc="[本] $item:39000001$を収集する" manualComplete="[本] $item:39000001$を収集する" feature="Season1" />

--- a/Xml/string/jp/achievename.xml
+++ b/Xml/string/jp/achievename.xml
@@ -1844,7 +1844,7 @@
   <key id="23200040" name="準備完了！" feature="Season1" />
   <key id="23200041" name="未来の自分のための投資" feature="Season1" />
   <key id="23200042" name="(アカウント) 甘い報酬" feature="SurvivalContents03" />
-  <key id="23200043" name="ACHIEVENAME_23200043_NAME:[F]UnlimitedEnchant" feature="UnlimitedEnchant" />
+  <key id="23200043" name="限界に挑戦" feature="UnlimitedEnchant" />
   <key id="23300002" name="もこもこ子羊" />
   <key id="23300003" name="トレンドセッター" />
   <key id="23300004" name="$item:39000001$" />

--- a/Xml/string/pt/achievedescription.xml
+++ b/Xml/string/pt/achievedescription.xml
@@ -1613,6 +1613,7 @@
 	<achieve id="23200040" desc="Atinja uma Pontuação de Equipamento de {0}" complete="Atingiu uma Pontuação de Equipamento de {0}" manualDesc="" manualComplete="" feature="Season1" />
 	<achieve id="23200041" desc="Gaste 500 merets no Mercado de Merets" complete="Gastou 500 merets no Mercado de Merets" manualDesc="" manualComplete="" feature="Season1" />
 	<achieve id="23200042" desc="Ative {0} Passe(s) Dourado(s) de Batalha" complete="Ativou {0} Passe(s) Dourado(s) de Batalha" manualDesc="" manualComplete="" feature="SurvivalContents03" />
+	<achieve id="23200043" desc="Complete Quebra de Limite {0} vez(es)" complete="Completou Quebra de Limite {0} vez(es)" manualDesc="" manualComplete="" feature="UnlimitedEnchant" />
 	<achieve id="23300002" desc="" complete="" manualDesc="Obtenha o troféu de transporte de Birk" manualComplete="Obteve o troféu de transporte de Birk" feature="Season1" />
 	<achieve id="23300003" desc="" complete="" manualDesc="Colete todas as revistas populares mais recentes" manualComplete="Coletou todas as revistas populares mais recentes" feature="Season1" />
 	<achieve id="23300004" desc="" complete="" manualDesc='Colete o livro &quot;$item:39000001$&quot;' manualComplete='Coletou o livro &quot;$item:39000001$&quot;' feature="Season1" />

--- a/Xml/string/pt/achievename.xml
+++ b/Xml/string/pt/achievename.xml
@@ -1724,6 +1724,7 @@
 	<key id="23200040" name="Pronto para as Ligas Profissionais" feature="Season1" />
 	<key id="23200041" name="Eu Preciso Disso!" feature="Season1" />
 	<key id="23200042" name="(Conta) Realeza" feature="SurvivalContents03" />
+	<key id="23200043" name="Superando os Limites" feature="UnlimitedEnchant" />
 	<key id="23300002" name="Ovelha Desgrenhada" />
 	<key id="23300003" name="Criador de Tendências" />
 	<key id="23300004" name="$item:39000001$" />


### PR DESCRIPTION
Trophy "Push The Limits" (UnlimitedEnchant) was missing from en/de/pt and had placeholder text in jp. cn/kr/kr_latest already had entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new achievement for Limit Break progression. Players can unlock this achievement by completing Limit Break challenges a specified number of times. The achievement now features full localization support with translated names, descriptions, and completion messages available in German, English, Japanese, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->