### PR TITLE
Propagate summonNpcIDs to all environment blocks of affected NPCs

### DIFF
--- a/Xml/npc/22/00/22000009.xml
+++ b/Xml/npc/22/00/22000009.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_Ureus.xml" />
+		<aiInfo path="AI_Ureus.xml" summonNpcIDs="21400006,21400007,21400008" />
 		<collision shape="box" width="180" height="180" depth="180" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="110" height="150" ignore="0" />

--- a/Xml/npc/22/00/22000045.xml
+++ b/Xml/npc/22/00/22000045.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_KnightHollowArmorWhite.xml" />
+		<aiInfo path="AI_KnightHollowArmorWhite.xml" summonNpcIDs="21400012" />
 		<collision shape="box" width="150" height="200" depth="150" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="110" height="150" ignore="0" />

--- a/Xml/npc/22/00/22000059.xml
+++ b/Xml/npc/22/00/22000059.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_ManoRed.xml" />
+		<aiInfo path="AI_ManoRed.xml" summonNpcIDs="21400011" />
 		<collision shape="box" width="150" height="100" depth="190" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="150" height="150" ignore="0" />

--- a/Xml/npc/22/09/22090007.xml
+++ b/Xml/npc/22/09/22090007.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_PuppetBunnySummoner.xml" />
+		<aiInfo path="AI_PuppetBunnySummoner.xml" summonNpcIDs="21400009,21400010" />
 		<collision shape="box" width="113.043" height="173.913" depth="113.043" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="90" height="180" ignore="0" />

--- a/Xml/npc/22/09/22090107.xml
+++ b/Xml/npc/22/09/22090107.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_KingSlimeNew.xml" />
+		<aiInfo path="AI_KingSlimeNew.xml" summonNpcIDs="21400005" />
 		<collision shape="box" width="200" height="160" depth="200" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="80" height="170" ignore="0" />

--- a/Xml/npc/23/10/23100007.xml
+++ b/Xml/npc/23/10/23100007.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="BossDungeon/DevilHugeBlue/AI_DevilHugeBlue.xml" />
+		<aiInfo path="BossDungeon/DevilHugeBlue/AI_DevilHugeBlue.xml" summonNpcIDs="21404189,21403189" />
 		<collision shape="box" width="450" height="400" depth="375" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="600" height="150" depth="380" added="220" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="345" />
 		<capsule radius="170" height="450" ignore="0" />

--- a/Xml/npc/23/20/23200016.xml
+++ b/Xml/npc/23/20/23200016.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_DevilHugeBlue_Chaos.xml" />
+		<aiInfo path="AI_DevilHugeBlue_Chaos.xml" summonNpcIDs="21400367,21401189,21400368,21402189" />
 		<collision shape="box" width="450" height="400" depth="375" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="600" height="150" depth="380" added="220" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="345" />
 		<capsule radius="170" height="450" ignore="0" />
@@ -62,7 +62,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_DevilHugeBlue_Chaos.xml" />
+		<aiInfo path="AI_DevilHugeBlue_Chaos.xml" summonNpcIDs="21400367,21401189,21400368,21402189" />
 		<collision shape="box" width="450" height="400" depth="375" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="600" height="150" depth="380" added="220" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="345" />
 		<capsule radius="170" height="450" ignore="0" />
@@ -87,7 +87,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_DevilHugeBlue_Chaos.xml" />
+		<aiInfo path="AI_DevilHugeBlue_Chaos.xml" summonNpcIDs="21400367,21401189,21400368,21402189" />
 		<collision shape="box" width="450" height="400" depth="375" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="600" height="150" depth="380" added="220" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="345" />
 		<capsule radius="170" height="450" ignore="0" />

--- a/Xml/npc/23/20/23200017.xml
+++ b/Xml/npc/23/20/23200017.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_CaptainHookFish01_Chaos.xml" />
+		<aiInfo path="AI_CaptainHookFish01_Chaos.xml" summonNpcIDs="21401230,21403229,21406229,21800910,21404229,21405229,21407229,21403228,21800903" />
 		<collision shape="box" width="140" height="170" depth="125" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="350" height="150" depth="300" added="0" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="150" height="320" ignore="0" />
@@ -62,7 +62,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_CaptainHookFish01_Chaos.xml" />
+		<aiInfo path="AI_CaptainHookFish01_Chaos.xml" summonNpcIDs="21401230,21403229,21406229,21800910,21404229,21405229,21407229,21403228,21800903" />
 		<collision shape="box" width="140" height="170" depth="125" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="350" height="150" depth="300" added="0" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="150" height="320" ignore="0" />
@@ -87,7 +87,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_CaptainHookFish01_Chaos.xml" />
+		<aiInfo path="AI_CaptainHookFish01_Chaos.xml" summonNpcIDs="21401230,21403229,21406229,21800910,21404229,21405229,21407229,21403228,21800903" />
 		<collision shape="box" width="140" height="170" depth="125" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="350" height="150" depth="300" added="0" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="150" height="320" ignore="0" />

--- a/Xml/npc/23/20/23200077.xml
+++ b/Xml/npc/23/20/23200077.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" />
+		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" summonNpcIDs="21403410,21404410,21406410,21407410,21400242,21401242,21405410" />
 		<collision shape="box" width="330" height="350" depth="230" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="300" height="150" depth="1" added="950" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="170" height="320" ignore="0" />
@@ -62,7 +62,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" />
+		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" summonNpcIDs="21403410,21404410,21406410,21407410,21400242,21401242,21405410" />
 		<collision shape="box" width="330" height="350" depth="230" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="300" height="150" depth="1" added="950" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="170" height="320" ignore="0" />
@@ -87,7 +87,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" />
+		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" summonNpcIDs="21403410,21404410,21406410,21407410,21400242,21401242,21405410" />
 		<collision shape="box" width="330" height="350" depth="230" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="300" height="150" depth="1" added="950" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="170" height="320" ignore="0" />
@@ -112,7 +112,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" />
+		<aiInfo path="BossDungeon/Papulatus_Chaos/AI_Papulatus_ChaosNA.xml" summonNpcIDs="21403410,21404410,21406410,21407410,21400242,21401242,21405410" />
 		<collision shape="box" width="330" height="350" depth="230" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="300" height="150" depth="1" added="950" offsetNametag="-200" corpseEffect="" hitAble="0" rotation="0" />
 		<capsule radius="170" height="320" ignore="0" />

--- a/Xml/npc/32/00/32002301.xml
+++ b/Xml/npc/32/00/32002301.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_MaskBoyTallElite_DarkStream.xml" />
+		<aiInfo path="AI_MaskBoyTallElite_DarkStream.xml" summonNpcIDs="32002302" />
 		<collision shape="box" width="80" height="130" depth="80" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="90" height="150" ignore="0" />

--- a/Xml/npc/32/00/32002601.xml
+++ b/Xml/npc/32/00/32002601.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_ZealotLeader_DarkStream.xml" />
+		<aiInfo path="AI_ZealotLeader_DarkStream.xml" summonNpcIDs="32002602,32002603" />
 		<collision shape="box" width="100" height="150" depth="100" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="130" height="150" ignore="0" />

--- a/Xml/npc/32/00/32002801.xml
+++ b/Xml/npc/32/00/32002801.xml
@@ -37,7 +37,7 @@
 		<interact interactFunction="" interactCastingAnimation="" interactCastingTime="0" interactCoolTime="0" interactIsShowCastingBar="true" />
 		<combat combatAbandonTick="0" impossibleCombatAbandonTick="0" ignoreExtendLifeTime="false" canShowHideTarget="false" />
 		<assist assistType1SkillCount="0" assistType2SkillCount="0" assistType2CheckTick="0" />
-		<aiInfo path="AI_PuppetBunnySummoner_DarkStream.xml" />
+		<aiInfo path="AI_PuppetBunnySummoner_DarkStream.xml" summonNpcIDs="32002802,32002803,32002804" />
 		<collision shape="box" width="113.043" height="173.913" depth="113.043" widthOffset="0" depthOffset="0" heightOffset="0" />
 		<corpse width="0" height="0" depth="0" added="0" offsetNametag="0" corpseEffect="" hitAble="0" rotation="" />
 		<capsule radius="90" height="180" ignore="0" />


### PR DESCRIPTION
## Background

An NPC's XML can contain several `<environment feature="…" locale="…">` blocks — one boss reused across different game modes, locales, or AI variants. Each block has its own `<aiInfo>`, and `summonNpcIDs` (the list of adds/minions the AI spawns) lives on that `<aiInfo>`.

A long-ago KMS2/GMS2 XML merge wrote `summonNpcIDs` onto only the **first** `<environment>` block of each NPC, leaving the sibling blocks — same boss, same fight — without it. The previous fix (commit `e5c888184`) patched one such NPC, `32001101`, by hand. This PR finds and fixes the rest.

## What's wrong

In an affected file, one block has the attribute and its siblings don't, even though they're the same boss:

```diff
  <environment feature="Season3" locale="NA"> … </environment>   ← had summonNpcIDs
  <environment feature="Season3" locale="JP"> … </environment>   ← missing
  <environment feature="Season3" locale="TH"> … </environment>   ← missing
  <environment feature="Season3" locale="TW"> … </environment>   ← missing
```

The merge was also imprecise about *which* block it picked. The KMS2 source confirms it: for `23100007`, KMS2 puts the summon on the `DungeonBoss_4P` feature, but the merge had stuck it on the wrong `Season1/CN` block. Propagating to every block produces the correct superset in all cases.

## The fix

For each NPC file under `Xml/npc/`, when there are ≥2 `<aiInfo>` tags and exactly **one** distinct non-empty `summonNpcIDs` value, that value is copied onto every `<aiInfo>` that lacks it — inserted right after `path="…"`, matching the existing attribute order. Files with multiple distinct values are left untouched (none exist today; this is just a guardrail).

Example (`23200016`):

```diff
- <aiInfo path="AI_DevilHugeBlue_Chaos.xml" />
+ <aiInfo path="AI_DevilHugeBlue_Chaos.xml" summonNpcIDs="21400367,21401189,21400368,21402189" />
```

## Scope

- Scanned 11,343 NPC files; **12** were affected, totalling **19** `aiInfo` tags.
- Edits are single-attribute insertions only — tabs, CRLF line endings, and encoding are byte-for-byte preserved, so the diff is exactly 19 one-line changes.

| File | aiInfo fixed |
|------|--------------|
| `22/00/22000009.xml` | 1 |
| `22/00/22000045.xml` | 1 |
| `22/00/22000059.xml` | 1 |
| `22/09/22090007.xml` | 1 |
| `22/09/22090107.xml` | 1 |
| `23/10/23100007.xml` | 1 |
| `23/20/23200016.xml` | 3 |
| `23/20/23200017.xml` | 3 |
| `23/20/23200077.xml` | 4 |
| `32/00/32002301.xml` | 1 |
| `32/00/32002601.xml` | 1 |
| `32/00/32002801.xml` | 1 |

## Verification

- Re-scan after the change: **zero** remaining "some-but-not-all" files.
- The transformation is idempotent (re-running makes no further changes).

## Note

For the locale-specific AI variants (e.g. `23200077`'s `AI_Papulatus_ChaosNA.xml`, `23100007`'s plain `AI_DevilHugeBlue.xml`) the same summon list was propagated, per the "add to all blocks" goal. If any of those AI files genuinely summon a *different* set, that distinction isn't present in the GMS2 data and would require the KMS2 AI definitions to recover. The change here is correct as a superset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NPC AI summoning configurations across multiple encounters in elite renewal, chaos boss, dungeon, and time attack modes. Modifications apply to summon behavior specifications and AI configuration synchronization to ensure consistency across various game environments. Changes affect numerous NPC combat interactions throughout the game.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MS2Community/MapleStory2-XML/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->