### PR TITLE
Send tutorial skip to Lith Harbor default spawn instead of Tria

### DIFF
--- a/Xml/table/job.xml
+++ b/Xml/table/job.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
-	<job code="001" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job code="001" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<startInvenItem>
 			<item itemID="13000001" grade="1" count="1" />
 		</startInvenItem>
@@ -28,7 +28,7 @@
 			<skill id="10000041" />
 		</learn>
 	</job>
-	<job code="010" characterBGM="152" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job code="010" characterBGM="152" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<characterVoice value="ko/Normal/Female/94100005" locale="" />
 		<startInvenItem>
 			<item itemID="13200220" grade="1" count="1" />
@@ -68,7 +68,7 @@
 			<skill id="10100061" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="010" characterBGM="152" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job feature="JobChange_01" code="010" characterBGM="152" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<characterVoice value="ko/Normal/Female/94100005" locale="" />
 		<startInvenItem>
 			<item itemID="13200220" grade="1" count="1" />
@@ -118,7 +118,7 @@
 			<skill id="10100231" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="010" characterBGM="152" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job feature="JobChange_02" code="010" characterBGM="152" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<characterVoice value="ko/Normal/Female/94100005" locale="" />
 		<startInvenItem>
 			<item itemID="13200220" grade="1" count="1" />
@@ -172,7 +172,7 @@
 			<skill id="10100231" />
 		</learn>
 	</job>
-	<job code="020" characterBGM="156" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job code="020" characterBGM="156" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91110005" locale="" />
 		<characterVoice value="ko/Normal/Male/90110005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90110005" locale="CN" />
@@ -212,7 +212,7 @@
 			<skill id="10200091" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="020" characterBGM="156" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="020" characterBGM="156" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91110005" locale="" />
 		<characterVoice value="ko/Normal/Male/90110005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90110005" locale="CN" />
@@ -262,7 +262,7 @@
 			<skill id="10200191" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="020" characterBGM="156" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="020" characterBGM="156" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91110005" locale="" />
 		<characterVoice value="ko/Normal/Male/90110005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90110005" locale="CN" />
@@ -316,7 +316,7 @@
 			<skill id="10200191" />
 		</learn>
 	</job>
-	<job code="030" characterBGM="150" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job code="030" characterBGM="150" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91120005" locale="" />
 		<startInvenItem>
 			<item itemID="15200223" grade="1" count="1" />
@@ -354,7 +354,7 @@
 			<skill id="10300061" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="030" characterBGM="150" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="030" characterBGM="150" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91120005" locale="" />
 		<startInvenItem>
 			<item itemID="15200223" grade="1" count="1" />
@@ -402,7 +402,7 @@
 			<skill id="10300171" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="030" characterBGM="150" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="030" characterBGM="150" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91120005" locale="" />
 		<startInvenItem>
 			<item itemID="15200223" grade="1" count="1" />
@@ -454,7 +454,7 @@
 			<skill id="10300171" />
 		</learn>
 	</job>
-	<job code="040" characterBGM="153" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job code="040" characterBGM="153" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<characterVoice value="ko/Normal/Female/91130005" locale="" />
 		<characterVoice value="ko/Normal/Male/90130005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90130005" locale="CN" />
@@ -496,7 +496,7 @@
 			<skill id="10400111" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="040" characterBGM="153" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job feature="JobChange_01" code="040" characterBGM="153" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<characterVoice value="ko/Normal/Female/91130005" locale="" />
 		<characterVoice value="ko/Normal/Male/90130005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90130005" locale="CN" />
@@ -548,7 +548,7 @@
 			<skill id="10400241" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="040" characterBGM="153" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
+	<job feature="JobChange_02" code="040" characterBGM="153" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH">
 		<characterVoice value="ko/Normal/Female/91130005" locale="" />
 		<characterVoice value="ko/Normal/Male/90130005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90130005" locale="CN" />
@@ -604,7 +604,7 @@
 			<skill id="10400241" />
 		</learn>
 	</job>
-	<job code="050" characterBGM="154" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job code="050" characterBGM="154" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91140005" locale="" />
 		<characterVoice value="ko/Normal/Male/90140005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90140005" locale="CN" />
@@ -644,7 +644,7 @@
 			<skill id="10500111" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="050" characterBGM="154" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="050" characterBGM="154" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91140005" locale="" />
 		<characterVoice value="ko/Normal/Male/90140005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90140005" locale="CN" />
@@ -694,7 +694,7 @@
 			<skill id="10500251" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="050" characterBGM="154" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="050" characterBGM="154" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91140005" locale="" />
 		<characterVoice value="ko/Normal/Male/90140005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90140005" locale="CN" />
@@ -748,7 +748,7 @@
 			<skill id="10500251" />
 		</learn>
 	</job>
-	<job code="060" characterBGM="151" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job code="060" characterBGM="151" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91150005" locale="" />
 		<characterVoice value="ko/Normal/Male/90150005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90150005" locale="CN" />
@@ -788,7 +788,7 @@
 			<skill id="10600081" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="060" characterBGM="151" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="060" characterBGM="151" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91150005" locale="" />
 		<characterVoice value="ko/Normal/Male/90150005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90150005" locale="CN" />
@@ -838,7 +838,7 @@
 			<skill id="10600221" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="060" characterBGM="151" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="060" characterBGM="151" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91150005" locale="" />
 		<characterVoice value="ko/Normal/Male/90150005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90150005" locale="CN" />
@@ -892,7 +892,7 @@
 			<skill id="10600221" />
 		</learn>
 	</job>
-	<job code="070" characterBGM="155" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
+	<job code="070" characterBGM="155" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
 		<characterVoice value="ko/Normal/Female/91160005" locale="" />
 		<characterVoice value="ko/Normal/Male/90160005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90160005" locale="CN" />
@@ -934,7 +934,7 @@
 			<skill id="10700041" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="070" characterBGM="155" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
+	<job feature="JobChange_01" code="070" characterBGM="155" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
 		<characterVoice value="ko/Normal/Female/91160005" locale="" />
 		<characterVoice value="ko/Normal/Male/90160005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90160005" locale="CN" />
@@ -986,7 +986,7 @@
 			<skill id="10700251" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="070" characterBGM="155" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
+	<job feature="JobChange_02" code="070" characterBGM="155" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
 		<characterVoice value="ko/Normal/Female/91160005" locale="" />
 		<characterVoice value="ko/Normal/Male/90160005" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90160005" locale="CN" />
@@ -1042,7 +1042,7 @@
 			<skill id="10700251" />
 		</learn>
 	</job>
-	<job code="080" characterBGM="149" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
+	<job code="080" characterBGM="149" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
 		<characterVoice value="ko/Normal/Female/91170005" locale="" />
 		<startInvenItem>
 			<item itemID="13400218" grade="1" count="1" />
@@ -1082,7 +1082,7 @@
 			<skill id="10800081" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="080" characterBGM="149" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
+	<job feature="JobChange_01" code="080" characterBGM="149" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
 		<characterVoice value="ko/Normal/Female/91170005" locale="" />
 		<startInvenItem>
 			<item itemID="13400218" grade="1" count="1" />
@@ -1132,7 +1132,7 @@
 			<skill id="10800231" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="080" characterBGM="149" startField="52000065" tutorialSaveID="" tutorialSkipField="02000001,21" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
+	<job feature="JobChange_02" code="080" characterBGM="149" startField="52000065" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="13000062" tutorialClearOpenTaxis="02000062" tutorialClearOpenMaps="02000062,02000114,02000115,02000116,02000117,02000118" defaultWeaponSlot="OH">
 		<characterVoice value="ko/Normal/Female/91170005" locale="" />
 		<startInvenItem>
 			<item itemID="13400218" grade="1" count="1" />
@@ -1186,7 +1186,7 @@
 			<skill id="10800231" />
 		</learn>
 	</job>
-	<job feature="RuneBlader" code="090" characterBGM="96" startField="63000006" tutorialSaveID="" tutorialSkipField="02000033,1" tutorialSkipItem="15400002" defaultWeaponSlot="RH,LH">
+	<job feature="RuneBlader" code="090" characterBGM="96" startField="63000006" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15400002" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91180005" locale="" />
 		<startInvenItem>
 			<item itemID="15400274" grade="1" count="1" />
@@ -1228,7 +1228,7 @@
 			<skill id="10900041" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="090" characterBGM="96" startField="63000006" tutorialSaveID="" tutorialSkipField="02000033,1" tutorialSkipItem="15400002" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="090" characterBGM="96" startField="63000006" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15400002" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91180005" locale="" />
 		<startInvenItem>
 			<item itemID="15400274" grade="1" count="1" />
@@ -1280,7 +1280,7 @@
 			<skill id="10900231" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="090" characterBGM="96" startField="63000006" tutorialSaveID="" tutorialSkipField="02000033,1" tutorialSkipItem="15400002" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="090" characterBGM="96" startField="63000006" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15400002" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91180005" locale="" />
 		<startInvenItem>
 			<item itemID="15400274" grade="1" count="1" />
@@ -1336,7 +1336,7 @@
 			<skill id="10900231" />
 		</learn>
 	</job>
-	<job feature="Striker" code="100" characterBGM="122" startField="63000015" tutorialSaveID="" tutorialSkipField="02000001,1" tutorialSkipItem="15500095" defaultWeaponSlot="RH,LH">
+	<job feature="Striker" code="100" characterBGM="122" startField="63000015" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15500095" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91900035" locale="" />
 		<characterVoice value="ko/Normal/Male/90900035" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90900035" locale="CN" />
@@ -1378,7 +1378,7 @@
 			<skill id="11000051" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="100" characterBGM="122" startField="63000015" tutorialSaveID="" tutorialSkipField="02000001,1" tutorialSkipItem="15500095" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="100" characterBGM="122" startField="63000015" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15500095" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91900035" locale="" />
 		<characterVoice value="ko/Normal/Male/90900035" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90900035" locale="CN" />
@@ -1430,7 +1430,7 @@
 			<skill id="11000291" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="100" characterBGM="122" startField="63000015" tutorialSaveID="" tutorialSkipField="02000001,1" tutorialSkipItem="15500095" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="100" characterBGM="122" startField="63000015" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15500095" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91900035" locale="" />
 		<characterVoice value="ko/Normal/Male/90900035" locale="KR" />
 		<characterVoice value="ko/Normal/Male/90900035" locale="CN" />
@@ -1486,7 +1486,7 @@
 			<skill id="11000291" />
 		</learn>
 	</job>
-	<job feature="SoulBinder" code="110" characterBGM="127" characterVoice="ko/Normal/Female/91900125" startField="63000035" tutorialSaveID="" tutorialSkipField="02000001,1" tutorialSkipItem="15600116" defaultWeaponSlot="RH,LH">
+	<job feature="SoulBinder" code="110" characterBGM="127" characterVoice="ko/Normal/Female/91900125" startField="63000035" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15600116" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91900125" locale="" />
 		<startInvenItem>
 			<item itemID="15600514" grade="1" count="1" />
@@ -1530,7 +1530,7 @@
 			<skill id="11100051" />
 		</learn>
 	</job>
-	<job feature="JobChange_01" code="110" characterBGM="127" characterVoice="ko/Normal/Female/91900125" startField="63000035" tutorialSaveID="" tutorialSkipField="02000001,1" tutorialSkipItem="15600116" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_01" code="110" characterBGM="127" characterVoice="ko/Normal/Female/91900125" startField="63000035" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15600116" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91900125" locale="" />
 		<startInvenItem>
 			<item itemID="15600514" grade="1" count="1" />
@@ -1584,7 +1584,7 @@
 			<skill id="11100062" />
 		</learn>
 	</job>
-	<job feature="JobChange_02" code="110" characterBGM="127" characterVoice="ko/Normal/Female/91900125" startField="63000035" tutorialSaveID="" tutorialSkipField="02000001,1" tutorialSkipItem="15600116" defaultWeaponSlot="RH,LH">
+	<job feature="JobChange_02" code="110" characterBGM="127" characterVoice="ko/Normal/Female/91900125" startField="63000035" tutorialSaveID="" tutorialSkipField="02000062" tutorialSkipItem="15600116" defaultWeaponSlot="RH,LH">
 		<characterVoice value="ko/Normal/Female/91900125" locale="" />
 		<startInvenItem>
 			<item itemID="15600514" grade="1" count="1" />


### PR DESCRIPTION
All 34 job entries' `tutorialSkipField` (Tria `02000001,21`/`02000001,1`, Troy Inn `02000033,1` on the RuneBlader variants) now point at `02000062` (Lith Harbor) with no portal id — the server's `SpawnPlayer` falls back to the map's default spawn point.

With the tutorial chapter cleared on skip, the epic chain picks up at The Caravan (60100000) in Lith Harbor, so skipping players now land right where their next quest is instead of in Tria.

Requires repacking `Xml.m2d` and re-running ingest to take effect (verified locally: all 12 ingested JobTable entries show `SkipField: 2000062`).