### PR TITLE
release: regenerate XML + verify before building m2d

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Regenerate translated XML from Weblate JSON
+        env:
+          MS2_REPO_ROOT: ${{ github.workspace }}
+        # Rebuild Xml/string/<locale> from the latest Weblate JSON so the released
+        # .m2d reflects current translations.
+        run: dotnet run --project WeblateConverter -c Release -- json-to-xml-all
+      - name: Verify conversion integrity
+        env:
+          MS2_REPO_ROOT: ${{ github.workspace }}
+        # Fail the release on any structural / key fault before packing.
+        run: dotnet run --project WeblateConverter -c Release -- verify-all
       - name: Build Server
         run: cd Tools && .\MS2Create.exe ../Server ../ Server MS2F
       - name: Build XML


### PR DESCRIPTION
Makes a manual version release (`vX.Y.Z` tag) rebuild the translated XML from the latest Weblate JSON before packing, so the released `.m2d` is always current.

On tag push, `release.yml` now:
1. Sets up .NET 8
2. `json-to-xml-all` — regenerates `Xml/string/<locale>` from the latest `WeblateConverter/Json`
3. `verify-all` — fails the release on any structural/key fault
4. builds `Server.m2d` + `Xml.m2d`, hashes, and publishes the release (unchanged)

No commit-back here (that's the nightly's job) — the release just packs fresh XML from the tagged commit's JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Release builds now verify translated content before publishing.
  * Releases are blocked when translation structure or key integrity checks fail.
  * Translation files are regenerated from the latest source data during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->