### PR TITLE
nightly: fix Detect step failing when translations changed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,13 +50,17 @@ jobs:
           git add -- Xml
           git diff --cached --quiet -- Xml
           # --quiet exits 0 when there are no staged changes, 1 when there are.
-          if ($LASTEXITCODE -eq 0) {
+          $changed = $LASTEXITCODE
+          if ($changed -eq 0) {
             "changed=false" >> $env:GITHUB_OUTPUT
             Write-Host "No translation changes since last run - nothing to publish."
           } else {
             "changed=true" >> $env:GITHUB_OUTPUT
             Write-Host "Translation changes detected."
           }
+          # `git diff --quiet` leaves $LASTEXITCODE=1 when changes exist; that is the
+          # expected signal, not a failure, so exit cleanly and let later steps gate on the output.
+          exit 0
 
       - name: Compute release date
         if: steps.detect.outputs.changed == 'true'


### PR DESCRIPTION
The `Nightly M2D` run failed at **Detect translation changes** with exit code 1 — precisely when it *did* find changes to publish.

`git diff --cached --quiet` returns exit code 1 to signal "there are staged changes," and GitHub's `pwsh` wrapper propagates that lingering `$LASTEXITCODE` as the step's exit code, so the step failed even though detection succeeded.

Fix: capture the result into a variable and `exit 0`; downstream steps still gate on the `changed` output.

(The release-workflow change from #56 is already on `main`; this is the missing companion fix that didn't make it into that squash merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)