### PR TITLE
Fix three cases where the converter silently drops entries

### DIFF
--- a/WeblateConverter/Converter/Converter.cs
+++ b/WeblateConverter/Converter/Converter.cs
@@ -575,9 +575,27 @@ public class Converter {
     // preserved automatically (they simply aren't rewritten). The one thing that needs cleaning
     // is the individual quest/script source files, which are replaced by the combined outputs
     // (questdescription_final.xml / scriptquest.xml) — remove them so they don't co-exist.
-    private void RemoveAbsorbedSourceFiles(string locale) {
+    private void RemoveAbsorbedSourceFiles(string locale, FileInfo[] jsonFiles) {
         string? projectRoot = GetProjectRoot();
         if (projectRoot == null) {
+            return;
+        }
+
+        // Only drop a split file when the combined output that absorbs it is actually going to be
+        // written for this locale. A partially translated locale (e.g. pt, which only has
+        // itemname.json and korflash.json) has no questdescription_final.json / scriptquest.json,
+        // so removing its quest files deletes translations and puts nothing back.
+        bool hasQuestOutput = false;
+        bool hasScriptOutput = false;
+        foreach (FileInfo jsonFile in jsonFiles) {
+            if (string.Equals(jsonFile.Name, "questdescription_final.json", StringComparison.OrdinalIgnoreCase)) {
+                hasQuestOutput = true;
+            } else if (string.Equals(jsonFile.Name, "scriptquest.json", StringComparison.OrdinalIgnoreCase)) {
+                hasScriptOutput = true;
+            }
+        }
+
+        if (!hasQuestOutput && !hasScriptOutput) {
             return;
         }
 
@@ -589,7 +607,7 @@ public class Converter {
 
         int removed = 0;
         foreach (string file in Directory.GetFiles(dir, "*.xml")) {
-            if (IsAbsorbedByCombinedOutput(Path.GetFileName(file))) {
+            if (IsAbsorbedByCombinedOutput(Path.GetFileName(file), hasQuestOutput, hasScriptOutput)) {
                 File.Delete(file);
                 removed++;
             }
@@ -600,9 +618,14 @@ public class Converter {
         }
     }
 
-    private static bool IsAbsorbedByCombinedOutput(string fileName) {
-        return fileName.StartsWith("questdescription_", StringComparison.OrdinalIgnoreCase)
-            || fileName.StartsWith("scriptquest_", StringComparison.OrdinalIgnoreCase);
+    private static bool IsAbsorbedByCombinedOutput(string fileName, bool hasQuestOutput, bool hasScriptOutput) {
+        if (fileName.StartsWith("questdescription_", StringComparison.OrdinalIgnoreCase)) {
+            return hasQuestOutput;
+        }
+        if (fileName.StartsWith("scriptquest_", StringComparison.OrdinalIgnoreCase)) {
+            return hasScriptOutput;
+        }
+        return false;
     }
 
     private bool ProcessJsonToXml(string locale) {
@@ -615,7 +638,7 @@ public class Converter {
 
         // Generation writes in place; drop the individual quest/script files that the combined
         // outputs replace so they don't co-exist.
-        RemoveAbsorbedSourceFiles(locale);
+        RemoveAbsorbedSourceFiles(locale, jsonFiles);
 
         bool anyFailure = false;
         foreach (FileInfo jsonFile in jsonFiles) {
@@ -1470,7 +1493,9 @@ public class Converter {
 
     private string GetXmlElementName(string fileName) {
         // Remove .json extension if present
-        string baseFileName = fileName.Replace(".json", "").Replace(".xml", "");
+        // Trim: "questdescription_famefield .xml" ships with a trailing space in its
+        // name, which otherwise misses the lookup and silently drops every entry.
+        string baseFileName = fileName.Replace(".json", "").Replace(".xml", "").Trim();
 
         // Create lookup dictionary for filename to XML element name mapping
         var elementNameLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
@@ -1520,7 +1545,11 @@ public class Converter {
             }, {
                 "pvpmode", "PVPMessage"
             }, {
+                "questdescription_daily", "quest"
+            }, {
                 "questdescription_dailymission", "quest"
+            }, {
+                "questdescription_eventjp", "quest"
             }, {
                 "questdescription_epic", "quest"
             }, {
@@ -1595,7 +1624,9 @@ public class Converter {
 
     private string GetKeyAttributeName(string fileName) {
         // Remove .json extension if present
-        string baseFileName = fileName.Replace(".json", "").Replace(".xml", "");
+        // Trim: "questdescription_famefield .xml" ships with a trailing space in its
+        // name, which otherwise misses the lookup and silently drops every entry.
+        string baseFileName = fileName.Replace(".json", "").Replace(".xml", "").Trim();
 
         // Create lookup dictionary for filename to key attribute name mapping
         var keyAttributeLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
@@ -1613,7 +1644,11 @@ public class Converter {
             }, {
                 "pvpmode", "key"
             }, {
+                "questdescription_daily", "questID"
+            }, {
                 "questdescription_dailymission", "questID"
+            }, {
+                "questdescription_eventjp", "questID"
             }, {
                 "questdescription_epic", "questID"
             }, {
@@ -1667,7 +1702,9 @@ public class Converter {
 
     private string? GetSecondaryKeyAttributeName(string fileName) {
         // Remove .json extension if present
-        string baseFileName = fileName.Replace(".json", "").Replace(".xml", "");
+        // Trim: "questdescription_famefield .xml" ships with a trailing space in its
+        // name, which otherwise misses the lookup and silently drops every entry.
+        string baseFileName = fileName.Replace(".json", "").Replace(".xml", "").Trim();
 
         // Create lookup dictionary for filename to secondary key attribute name mapping
         var secondaryKeyLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {

--- a/WeblateConverter/Converter/Converter.cs
+++ b/WeblateConverter/Converter/Converter.cs
@@ -575,27 +575,16 @@ public class Converter {
     // preserved automatically (they simply aren't rewritten). The one thing that needs cleaning
     // is the individual quest/script source files, which are replaced by the combined outputs
     // (questdescription_final.xml / scriptquest.xml) — remove them so they don't co-exist.
-    private void RemoveAbsorbedSourceFiles(string locale, FileInfo[] jsonFiles) {
+    private void RemoveAbsorbedSourceFiles(string locale, bool questWritten, bool scriptWritten) {
         string? projectRoot = GetProjectRoot();
         if (projectRoot == null) {
             return;
         }
 
-        // Only drop a split file when the combined output that absorbs it is actually going to be
-        // written for this locale. A partially translated locale (e.g. pt, which only has
-        // itemname.json and korflash.json) has no questdescription_final.json / scriptquest.json,
-        // so removing its quest files deletes translations and puts nothing back.
-        bool hasQuestOutput = false;
-        bool hasScriptOutput = false;
-        foreach (FileInfo jsonFile in jsonFiles) {
-            if (string.Equals(jsonFile.Name, "questdescription_final.json", StringComparison.OrdinalIgnoreCase)) {
-                hasQuestOutput = true;
-            } else if (string.Equals(jsonFile.Name, "scriptquest.json", StringComparison.OrdinalIgnoreCase)) {
-                hasScriptOutput = true;
-            }
-        }
-
-        if (!hasQuestOutput && !hasScriptOutput) {
+        // Only drop a family's fragments when its combined output was actually WRITTEN this run
+        // (not merely when the JSON exists). A partially translated locale, an empty combined JSON,
+        // or a failed conversion writes nothing — deleting the fragments then would lose data.
+        if (!questWritten && !scriptWritten) {
             return;
         }
 
@@ -607,7 +596,7 @@ public class Converter {
 
         int removed = 0;
         foreach (string file in Directory.GetFiles(dir, "*.xml")) {
-            if (IsAbsorbedByCombinedOutput(Path.GetFileName(file), hasQuestOutput, hasScriptOutput)) {
+            if (IsAbsorbedByCombinedOutput(Path.GetFileName(file), questWritten, scriptWritten)) {
                 File.Delete(file);
                 removed++;
             }
@@ -618,12 +607,17 @@ public class Converter {
         }
     }
 
-    private static bool IsAbsorbedByCombinedOutput(string fileName, bool hasQuestOutput, bool hasScriptOutput) {
+    private static bool IsAbsorbedByCombinedOutput(string fileName, bool questWritten, bool scriptWritten) {
+        // Never delete the combined outputs themselves, even though they share the fragment prefix.
+        if (fileName.Equals("questdescription_final.xml", StringComparison.OrdinalIgnoreCase)
+            || fileName.Equals("scriptquest.xml", StringComparison.OrdinalIgnoreCase)) {
+            return false;
+        }
         if (fileName.StartsWith("questdescription_", StringComparison.OrdinalIgnoreCase)) {
-            return hasQuestOutput;
+            return questWritten;
         }
         if (fileName.StartsWith("scriptquest_", StringComparison.OrdinalIgnoreCase)) {
-            return hasScriptOutput;
+            return scriptWritten;
         }
         return false;
     }
@@ -636,11 +630,9 @@ public class Converter {
             return false;
         }
 
-        // Generation writes in place; drop the individual quest/script files that the combined
-        // outputs replace so they don't co-exist.
-        RemoveAbsorbedSourceFiles(locale, jsonFiles);
-
         bool anyFailure = false;
+        bool questFinalWritten = false;
+        bool scriptFinalWritten = false;
         foreach (FileInfo jsonFile in jsonFiles) {
             Console.WriteLine($"Converting {jsonFile.Name} to XML...");
 
@@ -675,11 +667,23 @@ public class Converter {
 
                     Console.WriteLine($"Successfully converted {jsonFile.Name} to {xmlFileName}");
                 }
+
+                // Reaching here means the file was written (non-empty, no exception). Record the
+                // combined outputs so their fragments are only removed after a real write.
+                if (jsonFile.Name == "questdescription_final.json") {
+                    questFinalWritten = true;
+                } else if (jsonFile.Name == "scriptquest.json") {
+                    scriptFinalWritten = true;
+                }
             } catch (Exception ex) {
                 Console.WriteLine($"Error converting {jsonFile.Name}: {ex.Message}");
                 anyFailure = true;
             }
         }
+
+        // Cleanup runs AFTER generation: drop the individual quest/script fragments only for a
+        // family whose combined output was actually written this run (never the combined itself).
+        RemoveAbsorbedSourceFiles(locale, questFinalWritten, scriptFinalWritten);
 
         return !anyFailure;
     }

--- a/WeblateConverter/Converter/Converter.cs
+++ b/WeblateConverter/Converter/Converter.cs
@@ -648,7 +648,7 @@ public class Converter {
 
                 // Handle questdescription_final.json specially - convert with sorted questIDs
                 if (jsonFile.Name == "questdescription_final.json") {
-                    ConvertQuestDescriptionFinalWithSorting(jsonContent, locale);
+                    questFinalWritten = ConvertQuestDescriptionFinalWithSorting(jsonContent, locale);
                 } else if (jsonFile.Name == "skillname.json") {
                     // Handle skillname.json specially - split into multiple XML files based on skill ID ranges
                     ConvertSkillNameWithSplitting(jsonContent, locale);
@@ -668,11 +668,9 @@ public class Converter {
                     Console.WriteLine($"Successfully converted {jsonFile.Name} to {xmlFileName}");
                 }
 
-                // Reaching here means the file was written (non-empty, no exception). Record the
-                // combined outputs so their fragments are only removed after a real write.
-                if (jsonFile.Name == "questdescription_final.json") {
-                    questFinalWritten = true;
-                } else if (jsonFile.Name == "scriptquest.json") {
+                // scriptquest uses the generic path, which writes all entries of a non-empty JSON;
+                // questdescription_final reports whether it actually wrote content (assigned above).
+                if (jsonFile.Name == "scriptquest.json") {
                     scriptFinalWritten = true;
                 }
             } catch (Exception ex) {
@@ -2196,7 +2194,9 @@ public class Converter {
         return xmlContent.Replace("'", "&apos;");
     }
 
-    private void ConvertQuestDescriptionFinalWithSorting(string jsonContent, string locale) {
+    // Returns true only if a non-empty questdescription_final.xml was written, so the caller can
+    // decide whether the source fragments it absorbs are safe to remove.
+    private bool ConvertQuestDescriptionFinalWithSorting(string jsonContent, string locale) {
         JObject jsonObject = JObject.Parse(jsonContent);
 
         // Create a list to store quest entries with their parsed quest IDs for sorting
@@ -2220,6 +2220,13 @@ public class Converter {
             }
         }
 
+        // No parseable quests: don't overwrite the existing questdescription_final.xml with an empty
+        // file, and report failure so its absorbed source fragments are NOT removed.
+        if (questEntries.Count == 0) {
+            Console.WriteLine("No valid quest entries in questdescription_final.json — leaving questdescription_final.xml untouched.");
+            return false;
+        }
+
         // Sort by quest ID in ascending order
         questEntries.Sort((a, b) => a.questId.CompareTo(b.questId));
 
@@ -2236,5 +2243,6 @@ public class Converter {
         SaveXmlFile("questdescription_final.xml", xmlContent, locale);
 
         Console.WriteLine($"Successfully converted questdescription_final.json to questdescription_final.xml with {questEntries.Count} quests sorted by questID");
+        return true;
     }
 }


### PR DESCRIPTION
Three separate bugs in `WeblateConverter` cause `json-to-xml-all` to lose data without failing. Because nothing errors, the loss only surfaces later as missing strings in-game.

Found while adopting the #55 JSON-source model on a fork, where the regenerated output was diffed against the pre-#55 tree.

### 1. Split quest files deleted with no replacement

`RemoveAbsorbedSourceFiles` deleted every `questdescription_*` / `scriptquest_*` file for a locale before checking whether the combined output that absorbs them would actually be written. A partially translated locale has no `questdescription_final.json` or `scriptquest.json`, so the files were deleted and nothing was put back.

`pt` is the clear case: it only has `itemname.json` and `korflash.json`, and lost 29 files holding roughly 20.9k translated attributes. Removal is now gated on the corresponding combined JSON being present.

### 2. Trailing space in a filename misses every lookup

`questdescription_famefield .xml` ships with a trailing space in its name. That misses the key-attribute lookup, falls back to the default `id`, finds no such attribute (the elements use `questID`), and drops all 106 entries. Fixed by trimming the lookup key, which also guards against any other stray whitespace.

### 3. Two files absent from the lookup tables

`questdescription_daily` and `questdescription_eventjp` were in neither the element-name nor the key-attribute table, which is the same failure mode as 2. Added to both, matching the other 19 `questdescription_*` entries.

### Evidence

`Xml/string/de` is the only locale that still has the famefield file, and `de` has no JSON so it was never regenerated. Running `xml-to-json de`:

| | famefield parse warnings | famefield questIDs reaching `questdescription_final.json` |
|---|---|---|
| before | 108 | 0 |
| after | 2 | 106 |

### Scope

This stops further loss but does not recover what is already gone. As of #55 the tree has no `pt` quest/script files, no `questdescription_daily`, and only the `de` copy of famefield. That content is still in the history before #55 if you want it restored, which I am happy to do as a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/MS2Community/codesmith/MapleStory2-XML/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787816115&installation_model_id=429323&pr_number=60&repository=MS2Community%2FMapleStory2-XML&return_to=https%3A%2F%2Fgithub.com%2FMS2Community%2FMapleStory2-XML%2Fpull%2F60&signature=1dc2df0219d463f82e71b75892ee087e529a70df8c1d4266e10876a1da05877d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented removal of locale-specific split fragment files when the corresponding combined output files weren’t successfully generated, preserving partially converted content.
  * Improved JSON-to-XML filename parsing by trimming trailing whitespace from derived lookup keys.
  * Added/updated conversion mappings so daily, daily mission, and event quest descriptions map correctly to the expected XML element and `questID` key attribute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->